### PR TITLE
[agent] enable looking up certs in OS native stores (#71)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,22 +4,17 @@ version = "1.16.2"
 edition = "2021"
 
 [dependencies]
-reqwest = { version = "0.12.15", features = ["blocking", "rustls-tls", "json"], default-features = false }
+reqwest = { version = "0.12.15", features = ["blocking", "rustls-tls", "rustls-tls-native-roots", "json"], default-features = false }
 config = "0.15.0"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = {version = "1.0.140"}
 log = { version = "0.4.22", features = ["kv"] }
 hostname = "0.4.0"
 network-interface = "2.0.0"
-signal-hook = "0.3.17"
-base64 = "0.22.1"
 mid = "3.0.0"
-tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["json"] }
 tracing-appender = "0.2.3"
 rolling-file = "0.2.0"
-rustls = { version ="0.23.13", features = ["ring"], default-features = false }
-rustls-platform-verifier = "0.5.0"
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.8.0"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -21,6 +21,7 @@ impl Client {
         with_proxy: bool,
     ) -> Client {
         let mut http_client = reqwest::blocking::Client::builder()
+            .use_rustls_tls()
             .connect_timeout(Duration::from_secs(2))
             .timeout(Duration::from_secs(5))
             .user_agent(format!("openbas-agent/{VERSION}"));


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* enable looking up certs in OS native stores

note this forces the client to use rustls as the TLS backend, so that it can interface with the rustls-native-certs crate.

The goal is achieved with activating the following two reqwest crate features:
* `rustls-tls` (implies `rustls-tls-webpki-roots`)
* `rustls-tls-native-roots`

And the following default behaviour is set:
* rustls-tls-native-roots: Enables TLS functionality provided by rustls, while using root certificates from the rustls-native-certs crate.
* rustls-tls-webpki-roots: Enables TLS functionality provided by rustls, while using root certificates from the webpki-roots crate. (this is enabled with feature

### How to test
1. Set up OpenBAS with a certificate signed by a custom CA (e.g. from a local PKI)
2. Install the CA cert in the target endpoint default OS store (see docs for the endpoint's platform)
> il faut installer le certificat dans le store windows (certlm.msc) ou alors sur les debian-dérivés c'est copier le cert dans /usr/local/share/ca-certificates/ et exécuter update-ca-certificates
4. Install an agent on endpoint
5. Agent is registered via HTTPS on the OBAS instance

### Related issues

* Close #71 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
