### PR TITLE
[agent] Fix info "is service" for macos

### DIFF
--- a/src/config/execution_details.rs
+++ b/src/config/execution_details.rs
@@ -115,7 +115,7 @@ impl ExecutionDetails {
             let is_elevated = Self::decode_output(&is_elevated_output.unwrap().clone().stdout);
             let is_service_output = Self::invoke_command(
                 executor,
-                "launchctl print gui/$(id -u)/openaev-agent-session",
+                "launchctl print gui/$(id -u)/io.filigran.openaev-agent-session",
                 args.as_slice(),
             );
             let is_service = Self::decode_output(&is_service_output.unwrap().clone().stdout);


### PR DESCRIPTION
Little fix for macos agent to know which type of agent is installed on the OpenAEV UI
