### PR TITLE
ci: force reinstall cargo-cache in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - run: cargo build --release
       - run: cargo test --release
       - run: |
-          cargo install cargo-cache
+          cargo install cargo-cache --force
           cargo-cache -a clean-unref
       - save_cache:
           key: cargo-{{ arch }}-{{ checksum "Cargo.toml" }}
@@ -81,7 +81,7 @@ jobs:
             curl.exe --fail-with-body -u samuel.hassine@filigran.io:$env:JFROG_TOKEN -T ./installer/windows/agent-installer-service-user.ps1 "https://filigran.jfrog.io/artifactory/openaev-agent/windows/openaev-agent-installer-service-user-$env:version.ps1"
             curl.exe --fail-with-body -u samuel.hassine@filigran.io:$env:JFROG_TOKEN -T ./installer/windows/agent-upgrade-service-user.ps1 "https://filigran.jfrog.io/artifactory/openaev-agent/windows/openaev-agent-upgrade-service-user-$env:version.ps1"
       - run: |
-          cargo install cargo-cache
+          cargo install cargo-cache --force
           cargo-cache -a clean-unref
       - save_cache:
           key: cargo-{{ arch }}-{{ checksum "Cargo.toml" }}
@@ -113,7 +113,7 @@ jobs:
       - run: $env:PATH = "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\ARM64\bin;" + $env:PATH; Invoke-Expression '& "$env:USERPROFILE\.cargo\bin\cargo" build --release'
       - run: $env:PATH = "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\ARM64\bin;" + $env:PATH; Invoke-Expression '& "$env:USERPROFILE\.cargo\bin\cargo" test --release'
       - run: |
-          cargo install cargo-cache
+          cargo install cargo-cache --force
           cargo-cache -a clean-unref
       - save_cache:
           key: cargo-{{ arch }}-{{ checksum "Cargo.toml" }}
@@ -172,7 +172,7 @@ jobs:
             curl.exe --fail-with-body -u samuel.hassine@filigran.io:$env:JFROG_TOKEN -T ./installer/windows/agent-installer-service-user.ps1 "https://filigran.jfrog.io/artifactory/openaev-agent/windows/openaev-agent-installer-service-user-$env:version.ps1"
             curl.exe --fail-with-body -u samuel.hassine@filigran.io:$env:JFROG_TOKEN -T ./installer/windows/agent-upgrade-service-user.ps1 "https://filigran.jfrog.io/artifactory/openaev-agent/windows/openaev-agent-upgrade-service-user-$env:version.ps1"
       - run: |
-          cargo install cargo-cache
+          cargo install cargo-cache --force
           cargo-cache -a clean-unref
       - save_cache:
           key: cargo-{{ arch }}-{{ checksum "Cargo.toml" }}
@@ -197,7 +197,7 @@ jobs:
       - run: . "$HOME/.cargo/env"; cargo test --release
       - run: strip ./target/x86_64-unknown-linux-musl/release/openaev-agent
       - run: |
-          cargo install cargo-cache
+          cargo install cargo-cache --force
           cargo-cache -a clean-unref
       - save_cache:
           key: cargo-{{ arch }}-{{ checksum "Cargo.toml" }}
@@ -231,7 +231,7 @@ jobs:
             curl --fail-with-body -usamuel.hassine@filigran.io:$JFROG_TOKEN -T ./installer/linux/agent-installer-service-user.sh "https://filigran.jfrog.io/artifactory/openaev-agent/linux/openaev-agent-installer-service-user-$version.sh"
             curl --fail-with-body -usamuel.hassine@filigran.io:$JFROG_TOKEN -T ./installer/linux/agent-upgrade-service-user.sh "https://filigran.jfrog.io/artifactory/openaev-agent/linux/openaev-agent-upgrade-service-user-$version.sh"
       - run: |
-          cargo install cargo-cache
+          cargo install cargo-cache --force
           cargo-cache -a clean-unref
       - save_cache:
           key: cargo-{{ arch }}-{{ checksum "Cargo.toml" }}
@@ -257,7 +257,7 @@ jobs:
       - run: . "$HOME/.cargo/env"; cargo test --release
       - run: strip ./target/aarch64-unknown-linux-musl/release/openaev-agent
       - run: |
-          cargo install cargo-cache
+          cargo install cargo-cache --force
           cargo-cache -a clean-unref
       - save_cache:
           key: cargo-{{ arch }}-{{ checksum "Cargo.toml" }}
@@ -292,7 +292,7 @@ jobs:
             curl --fail-with-body -usamuel.hassine@filigran.io:$JFROG_TOKEN -T ./installer/linux/agent-installer-service-user.sh "https://filigran.jfrog.io/artifactory/openaev-agent/linux/openaev-agent-installer-service-user-$version.sh"
             curl --fail-with-body -usamuel.hassine@filigran.io:$JFROG_TOKEN -T ./installer/linux/agent-upgrade-service-user.sh "https://filigran.jfrog.io/artifactory/openaev-agent/linux/openaev-agent-upgrade-service-user-$version.sh"
       - run: |
-          cargo install cargo-cache
+          cargo install cargo-cache --force
           cargo-cache -a clean-unref
       - save_cache:
           key: cargo-{{ arch }}-{{ checksum "Cargo.toml" }}
@@ -315,7 +315,7 @@ jobs:
       - run: . "$HOME/.cargo/env"; cargo test --release
       - run: strip ./target/release/openaev-agent
       - run: |
-          cargo install cargo-cache
+          cargo install cargo-cache --force
           cargo-cache -a clean-unref
       - save_cache:
           key: cargo-{{ arch }}-{{ checksum "Cargo.toml" }}
@@ -347,7 +347,7 @@ jobs:
             curl --fail-with-body -usamuel.hassine@filigran.io:$JFROG_TOKEN -T ./installer/macos/agent-installer-service-user.sh "https://filigran.jfrog.io/artifactory/openaev-agent/macos/openaev-agent-installer-service-user-$version.sh"
             curl --fail-with-body -usamuel.hassine@filigran.io:$JFROG_TOKEN -T ./installer/macos/agent-upgrade-service-user.sh "https://filigran.jfrog.io/artifactory/openaev-agent/macos/openaev-agent-upgrade-service-user-$version.sh"
       - run: |
-          cargo install cargo-cache
+          cargo install cargo-cache --force
           cargo-cache -a clean-unref
       - save_cache:
           key: cargo-{{ arch }}-{{ checksum "Cargo.toml" }}


### PR DESCRIPTION
when releasing agent we ofter face this failure is coming from this line:
```
error: binary `cargo-cache.exe` already exists in destination
Add --force to overwrite
```
So cargo install is failing because the tool is already installed, and by default Cargo refuses to overwrite an existing binary → hence the exit code 1.

CircleCI often:

restores a cache (which includes ~/.cargo/bin)
then runs cargo install again

So the binary is already there → install fails.

Solution: allow overwrite with `force` option

<!--
Thank you very much for your pull request to the OpenAEV project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Testing Instructions

1. Step-by-step how to test
2. Environment or config notes

### Related issues

* Closes #ISSUE-NUMBER
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...-->
