### PR TITLE
fix(thread): agent internal Rust thread killed when panic error (#159)

### DIFF
--- a/src/api/manage_jobs.rs
+++ b/src/api/manage_jobs.rs
@@ -21,9 +21,16 @@ impl Client {
         executed_by_user: String,
         tenant_id: String,
     ) -> Result<Vec<JobResponse>, Error> {
+        let asset_external_reference = mid::get("openaev").map_err(|e| {
+            // If we get a panic error in a thread, the thread is killed and not relaunched
+            // So if we don't get the external reference, we manage the error to execute the code again during the next ping
+            error!("Error generating external reference in list_jobs: {}", e);
+            Error::Internal(e.to_string())
+        })?;
+
         // Post the input to the OpenAEV API
         let post_data = json!({
-          "asset_external_reference": mid::get("openaev").unwrap(),
+          "asset_external_reference": asset_external_reference,
           "agent_is_service": is_service,
           "agent_is_elevated": is_elevated,
           "agent_executed_by_user": executed_by_user

--- a/src/api/register_agent.rs
+++ b/src/api/register_agent.rs
@@ -1,6 +1,6 @@
 use super::Client;
 use crate::common::error_model::Error;
-use log::{error};
+use log::error;
 use network_interface::NetworkInterface;
 use network_interface::NetworkInterfaceConfig;
 use serde::Deserialize;
@@ -86,7 +86,10 @@ impl Client {
         let asset_external_reference = mid::get("openaev").map_err(|e| {
             // If we get a panic error in a thread, the thread is killed and not relaunched
             // So if we don't get the external reference, we manage the error to execute the code again during the next ping
-            error!("Error generating external reference in register_agent: {}", e);
+            error!(
+                "Error generating external reference in register_agent: {}",
+                e
+            );
             Error::Internal(e.to_string())
         })?;
 

--- a/src/api/register_agent.rs
+++ b/src/api/register_agent.rs
@@ -1,6 +1,6 @@
 use super::Client;
 use crate::common::error_model::Error;
-use log::error;
+use log::{error};
 use network_interface::NetworkInterface;
 use network_interface::NetworkInterfaceConfig;
 use serde::Deserialize;
@@ -82,9 +82,17 @@ impl Client {
                 && !ip.starts_with(IP_ADDRESS_FILTERED_2)
                 && !ip.starts_with(IP_ADDRESS_FILTERED_3)
         });
+
+        let asset_external_reference = mid::get("openaev").map_err(|e| {
+            // If we get a panic error in a thread, the thread is killed and not relaunched
+            // So if we don't get the external reference, we manage the error to execute the code again during the next ping
+            error!("Error generating external reference in register_agent: {}", e);
+            Error::Internal(e.to_string())
+        })?;
+
         let post_data = json!({
           "asset_name": hostname::get()?.to_string_lossy(),
-          "asset_external_reference": mid::get("openaev").unwrap(),
+          "asset_external_reference": asset_external_reference,
           "endpoint_agent_version": VERSION,
           "endpoint_ips": ip_addresses,
           "endpoint_platform": get_operating_system(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,8 +110,7 @@ fn agent_start(settings_data: Settings, is_service: bool) -> Result<Vec<JoinHand
 
 fn main() -> Result<(), Error> {
     set_error_hook();
-    let settings = Settings::new();
-    let settings_data = settings.unwrap();
+    let settings_data = Settings::new().map_err(|e| Error::Internal(e.to_string()))?;
     // region Init logger
     let current_exe_patch = env::current_exe().unwrap();
     let parent_path = current_exe_patch.parent().unwrap();
@@ -123,7 +122,7 @@ fn main() -> Result<(), Error> {
     let max_level = if settings_data.debug {
         LevelFilter::DEBUG
     } else {
-        LevelFilter::ERROR
+        LevelFilter::INFO
     };
 
     tracing_subscriber::fmt()

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ use crate::config::settings::Settings;
 use crate::process::agent_job;
 use crate::process::{agent_cleanup, keep_alive};
 use crate::windows::service::service_stub;
+use tracing_subscriber::filter::LevelFilter;
 
 pub static THREADS_CONTROL: AtomicBool = AtomicBool::new(true);
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -109,6 +110,8 @@ fn agent_start(settings_data: Settings, is_service: bool) -> Result<Vec<JoinHand
 
 fn main() -> Result<(), Error> {
     set_error_hook();
+    let settings = Settings::new();
+    let settings_data = settings.unwrap();
     // region Init logger
     let current_exe_patch = env::current_exe().unwrap();
     let parent_path = current_exe_patch.parent().unwrap();
@@ -116,15 +119,22 @@ fn main() -> Result<(), Error> {
     let condition = RollingConditionBasic::new().daily();
     let file_appender = BasicRollingFileAppender::new(log_file, condition, 3).unwrap();
     let (file_writer, _guard) = tracing_appender::non_blocking(file_appender);
+
+    let max_level = if settings_data.debug {
+        LevelFilter::DEBUG
+    } else {
+        LevelFilter::ERROR
+    };
+
     tracing_subscriber::fmt()
         .json()
+        .with_max_level(max_level)
         .with_writer(file_writer)
         .init();
     // endregion
+
     // region Process execution
     info!("Starting OpenAEV agent {} ({})", VERSION, Settings::mode());
-    let settings = Settings::new();
-    let settings_data = settings.unwrap();
     if service_stub::is_windows_service() {
         // Running as a Windows service
         agent_start(settings_data, true).unwrap();

--- a/src/process/agent_cleanup.rs
+++ b/src/process/agent_cleanup.rs
@@ -1,6 +1,6 @@
 use crate::config::settings::CleanupSettings;
 use crate::THREADS_CONTROL;
-use log::info;
+use log::{error, info};
 use std::fs::{DirEntry, File};
 use std::io::{Error, Write};
 use std::process::Command;
@@ -108,7 +108,14 @@ pub fn clean(cleanup: CleanupSettings) -> Result<JoinHandle<()>, Error> {
                 kill_processes_for_directory(dirname);
                 // After kill, rename from execution to executed
                 info!("[cleanup thread] Renaming runtime directory {dirname}");
-                fs::rename(dirname, dirname.replace("execution", "executed")).unwrap();
+                if let Err(err) = fs::rename(dirname, dirname.replace("execution", "executed")) {
+                    // If we get a panic error in a thread, the thread is killed and not relaunched
+                    // So if we can't rename, we log the error and continue
+                    error!(
+                        "[cleanup thread] Failed to rename runtime directory {}: {}",
+                        dirname, err
+                    );
+                }
             }
             let rename_payloads_directories =
                 get_old_execution_directories("payloads", EXECUTION_PREFIX, executing_max_time)
@@ -117,7 +124,14 @@ pub fn clean(cleanup: CleanupSettings) -> Result<JoinHandle<()>, Error> {
                 let dir_path = dir.path();
                 let dirname = dir_path.to_str().unwrap();
                 info!("[cleanup thread] Renaming payload directory {dirname}");
-                fs::rename(dirname, dirname.replace("execution", "executed")).unwrap();
+                if let Err(err) = fs::rename(dirname, dirname.replace("execution", "executed")) {
+                    // If we get a panic error in a thread, the thread is killed and not relaunched
+                    // So if we can't rename, we log the error and continue
+                    error!(
+                        "[cleanup thread] Failed to rename payload directory {}: {}",
+                        dirname, err
+                    );
+                }
             }
             // endregion
 
@@ -129,7 +143,14 @@ pub fn clean(cleanup: CleanupSettings) -> Result<JoinHandle<()>, Error> {
                 let dir_path = dir.path();
                 let dirname = dir_path.to_str().unwrap();
                 info!("[cleanup thread] Removing runtime directory {dirname}");
-                fs::remove_dir_all(dir_path).unwrap()
+                if let Err(err) = fs::remove_dir_all(&dir_path) {
+                    // If we get a panic error in a thread, the thread is killed and not relaunched
+                    // So if we can't remove, we log the error and continue
+                    error!(
+                        "[cleanup thread] Failed to remove runtime directory {}: {}",
+                        dirname, err
+                    );
+                }
             }
             let remove_payloads_directories =
                 get_old_execution_directories("payloads", EXECUTED_PREFIX, directory_max_time)
@@ -138,7 +159,14 @@ pub fn clean(cleanup: CleanupSettings) -> Result<JoinHandle<()>, Error> {
                 let dir_path = dir.path();
                 let dirname = dir_path.to_str().unwrap();
                 info!("[cleanup thread] Removing payload directory {dirname}");
-                fs::remove_dir_all(dir_path).unwrap()
+                if let Err(err) = fs::remove_dir_all(&dir_path) {
+                    // If we get a panic error in a thread, the thread is killed and not relaunched
+                    // So if we can't remove, we log the error and continue
+                    error!(
+                        "[cleanup thread] Failed to remove payload directory {}: {}",
+                        dirname, err
+                    );
+                }
             }
             // endregion
             // Wait for the next cleanup

--- a/src/process/agent_cleanup.rs
+++ b/src/process/agent_cleanup.rs
@@ -175,4 +175,3 @@ pub fn clean(cleanup: CleanupSettings) -> Result<JoinHandle<()>, Error> {
     });
     Ok(handle)
 }
-

--- a/src/process/agent_cleanup.rs
+++ b/src/process/agent_cleanup.rs
@@ -34,8 +34,8 @@ fn get_old_execution_directories(
             let file_entry = entry.as_ref().unwrap();
             let file_name = file_entry.file_name();
             let metadata = fs::metadata(file_entry.path()).unwrap();
-            let file_name_str = file_name.to_str().unwrap();
-            if metadata.is_dir() && String::from(file_name_str).contains(path) {
+            let file_name_str = file_name.to_string_lossy();
+            if metadata.is_dir() && file_name_str.contains(path) {
                 let file_modified = metadata.modified().unwrap();
                 let old_minutes = now.duration_since(file_modified).unwrap().as_secs() / 60;
                 return old_minutes > since_minutes;
@@ -103,12 +103,12 @@ pub fn clean(cleanup: CleanupSettings) -> Result<JoinHandle<()>, Error> {
                     .unwrap();
             for dir in kill_runtimes_directories {
                 let dir_path = dir.path();
-                let dirname = dir_path.to_str().unwrap();
+                let dirname = dir_path.to_string_lossy().into_owned();
                 info!("[cleanup thread] Killing process for runtime directory {dirname}");
-                kill_processes_for_directory(dirname);
+                kill_processes_for_directory(&dirname);
                 // After kill, rename from execution to executed
                 info!("[cleanup thread] Renaming runtime directory {dirname}");
-                if let Err(err) = fs::rename(dirname, dirname.replace("execution", "executed")) {
+                if let Err(err) = fs::rename(&dirname, dirname.replace("execution", "executed")) {
                     // If we get a panic error in a thread, the thread is killed and not relaunched
                     // So if we can't rename, we log the error and continue
                     error!(
@@ -122,9 +122,9 @@ pub fn clean(cleanup: CleanupSettings) -> Result<JoinHandle<()>, Error> {
                     .unwrap();
             for dir in rename_payloads_directories {
                 let dir_path = dir.path();
-                let dirname = dir_path.to_str().unwrap();
+                let dirname = dir_path.to_string_lossy().into_owned();
                 info!("[cleanup thread] Renaming payload directory {dirname}");
-                if let Err(err) = fs::rename(dirname, dirname.replace("execution", "executed")) {
+                if let Err(err) = fs::rename(&dirname, dirname.replace("execution", "executed")) {
                     // If we get a panic error in a thread, the thread is killed and not relaunched
                     // So if we can't rename, we log the error and continue
                     error!(
@@ -141,7 +141,7 @@ pub fn clean(cleanup: CleanupSettings) -> Result<JoinHandle<()>, Error> {
                     .unwrap();
             for dir in remove_runtimes_directories {
                 let dir_path = dir.path();
-                let dirname = dir_path.to_str().unwrap();
+                let dirname = dir_path.to_string_lossy().into_owned();
                 info!("[cleanup thread] Removing runtime directory {dirname}");
                 if let Err(err) = fs::remove_dir_all(&dir_path) {
                     // If we get a panic error in a thread, the thread is killed and not relaunched
@@ -157,7 +157,7 @@ pub fn clean(cleanup: CleanupSettings) -> Result<JoinHandle<()>, Error> {
                     .unwrap();
             for dir in remove_payloads_directories {
                 let dir_path = dir.path();
-                let dirname = dir_path.to_str().unwrap();
+                let dirname = dir_path.to_string_lossy().into_owned();
                 info!("[cleanup thread] Removing payload directory {dirname}");
                 if let Err(err) = fs::remove_dir_all(&dir_path) {
                     // If we get a panic error in a thread, the thread is killed and not relaunched
@@ -175,3 +175,4 @@ pub fn clean(cleanup: CleanupSettings) -> Result<JoinHandle<()>, Error> {
     });
     Ok(handle)
 }
+


### PR DESCRIPTION
### Proposed changes

* Manage the possible panic errors to keep the internal Rust thread always on.

### Testing Instructions

1. Check everything is working as before

### Related issues

* Closes #159 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
