### PR TITLE
fix(linux-scripts): fix linux scripts when systemd is degraded + imp… (#5871)

### DIFF
--- a/installer/linux/agent-installer-service-user.sh
+++ b/installer/linux/agent-installer-service-user.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+log() { printf '%s\n' "$*" >&2; }
+die() { log "[ERROR] $*"; exit 1; }
+run() {
+  "$@" || die "$*"
+}
+
 # --- Parse command-line arguments ---
 USER_ARG=""
 GROUP_ARG=""
@@ -25,25 +31,21 @@ done
 
 # --- Validate that user and group are provided ---
 if [ -z "$USER_ARG" ]; then
-  echo "Error: --user argument is required and cannot be empty."
-  exit 1
+  die "Error: --user argument is required and cannot be empty."
 fi
 
 if [ -z "$GROUP_ARG" ]; then
-  echo "Error: --group argument is required and cannot be empty. You can find your groups with the command 'id'."
-  exit 1
+  die "Error: --group argument is required and cannot be empty. You can find your groups with the command 'id'."
 fi
 
 # --- Verify that the user exists ---
 if ! id "$USER_ARG" >/dev/null 2>&1; then
-  echo "Error: User '$USER_ARG' does not exist."
-  exit 1
+  die "Error: User '$USER_ARG' does not exist."
 fi
 
 # --- Verify that the group exists ---
 if ! getent group "$GROUP_ARG" >/dev/null 2>&1; then
-  echo "Error: Group '$GROUP_ARG' does not exist. You can find your groups with the command 'id'."
-  exit 1
+  die "Error: Group '$GROUP_ARG' does not exist. You can find your groups with the command 'id'."
 fi
 
 base_url=${OPENAEV_URL}
@@ -53,41 +55,39 @@ group="$GROUP_ARG"
 
 home_dir="$(getent passwd "${user}" | cut -d: -f6 || true)"
 if [ -z "${home_dir}" ]; then
-  echo "Error: unable to resolve home directory for user '${user}' via getent passwd."
-  exit 1
+  die "Error: unable to resolve home directory for user '${user}' via getent passwd."
 fi
 
 os=$(uname | tr '[:upper:]' '[:lower:]')
-systemd_status=$(systemctl is-system-running)
+systemd_status=$(systemctl is-system-running 2>/dev/null || true)
 install_dir="${home_dir}/${OPENAEV_INSTALL_DIR}-${user}"
 service_name="${user}-${OPENAEV_SERVICE_NAME}"
 tenant_id="${OPENAEV_TENANT_ID}"
 
 
 if [ "${os}" != "linux" ]; then
-  echo "Operating system $OSTYPE is not supported yet, please create a ticket in openaev github project"
-  exit 1
+  die "Operating system $OSTYPE is not supported yet, please create a ticket in openaev github project"
 fi
 
 if [ "$systemd_status" != "running" ] && [ "$systemd_status" != "degraded" ]; then
-  echo "Systemd is in unexpected state: $systemd_status. Installation is not supported."
-  exit 1
+  die "Systemd is in unexpected state: $systemd_status. Installation is not supported."
 else
-  echo "Systemd is in acceptable state: $systemd_status"
+  log "Systemd is in acceptable state: $systemd_status"
 fi
 
-echo "Starting install script for ${os} | ${architecture}"
+log "Starting install script for ${os} | ${architecture}"
 
-echo "01. Stopping existing ${service_name}..."
-systemctl stop ${service_name} || echo "Fail stopping ${service_name}"
+log "01. Stopping existing ${service_name}..."
+systemctl stop ${service_name} || log "Fail stopping ${service_name}"
 
-echo "02. Downloading OpenAEV Agent into ${install_dir}..."
-(mkdir -p ${install_dir} && touch ${install_dir} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to ${install_dir}\n" >&2 && exit 1)
-curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent
-chmod +x ${install_dir}/openaev-agent
+log "02. Downloading OpenAEV Agent into ${install_dir}..."
+run mkdir -p "${install_dir}"
+[ -w "${install_dir}" ] || die "Can't write to ${install_dir}"
+run curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent
+run chmod +x ${install_dir}/openaev-agent
 
-echo "03. Creating OpenAEV configuration file"
-cat > ${install_dir}/openaev-agent-config.toml <<EOF
+log "03. Creating OpenAEV configuration file"
+cat > ${install_dir}/openaev-agent-config.toml <<EOF || die "Unable to write ${install_dir}/openaev-agent-config.toml"
 debug=false
 
 [openaev]
@@ -100,8 +100,8 @@ service_name = "${OPENAEV_SERVICE_NAME}"
 tenant_id = "${OPENAEV_TENANT_ID}"
 EOF
 
-echo "04. Writing agent service"
-cat > ${install_dir}/${service_name}.service <<EOF
+log "04. Writing agent service"
+cat > ${install_dir}/${service_name}.service <<EOF || die "Unable to write ${install_dir}/${session_name}.service"
 [Unit]
 Description=OpenAEV Agent Service ${user}
 After=network.target
@@ -117,13 +117,11 @@ RestartSec=60
 WantedBy=multi-user.target
 EOF
 
-chown -R ${user}:${group} ${install_dir}
-echo "05. Starting agent service"
-(
-  ln -sf ${install_dir}/${service_name}.service /etc/systemd/system/
-  systemctl daemon-reload
-  systemctl enable ${service_name}
-  systemctl start ${service_name}
-) || (echo "Error while enabling OpenAEV Agent systemd unit file or starting the agent" >&2 && exit 1)
+run chown -R ${user}:${group} ${install_dir}
+log "05. Starting agent service"
+run ln -sf ${install_dir}/${service_name}.service /etc/systemd/system/
+run systemctl daemon-reload
+run systemctl enable ${service_name}
+run systemctl start ${service_name}
 
-echo "OpenAEV Agent started."
+log "OpenAEV Agent started."

--- a/installer/linux/agent-installer-service-user.sh
+++ b/installer/linux/agent-installer-service-user.sh
@@ -101,7 +101,7 @@ tenant_id = "${OPENAEV_TENANT_ID}"
 EOF
 
 log "04. Writing agent service"
-cat > ${install_dir}/${service_name}.service <<EOF || die "Unable to write ${install_dir}/${session_name}.service"
+cat > ${install_dir}/${service_name}.service <<EOF || die "Unable to write ${install_dir}/${service_name}.service"
 [Unit]
 Description=OpenAEV Agent Service ${user}
 After=network.target

--- a/installer/linux/agent-installer-session-user.sh
+++ b/installer/linux/agent-installer-session-user.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 set -e
 
+log() { printf '%s\n' "$*" >&2; }
+die() { log "[ERROR] $*"; exit 1; }
+run() {
+  "$@" || die "$*"
+}
+
 base_url=${OPENAEV_URL}
-architecture=$(uname -m)
-systemd_status=$(systemctl is-system-running)
+architecture=$(run uname -m)
+systemd_status=$(systemctl is-system-running 2>/dev/null || true)
 
 os=$(uname | tr '[:upper:]' '[:lower:]')
 install_dir="$HOME/${OPENAEV_INSTALL_DIR}"
@@ -12,30 +18,28 @@ systemd_unit_dir="$HOME/.config/systemd/user/"
 tenant_id="${OPENAEV_TENANT_ID}"
 
 if [ "${os}" != "linux" ]; then
-  echo "Operating system $OSTYPE is not supported yet, please create a ticket in openaev github project"
-  exit 1
+  die "Operating system $OSTYPE is not supported yet, please create a ticket in openaev github project"
 fi
-
 
 if [ "$systemd_status" != "running" ] && [ "$systemd_status" != "degraded" ]; then
-  echo "Systemd is in unexpected state: $systemd_status. Installation is not supported."
-  exit 1
+  die "Systemd is in unexpected state: $systemd_status. Installation is not supported."
 else
-  echo "Systemd is in acceptable state: $systemd_status"
+  log "Systemd is in acceptable state: $systemd_status"
 fi
 
-echo "Starting install script for ${os} | ${architecture}"
+log "Starting install script for ${os} | ${architecture}"
 
-echo "01. Stopping existing ${session_name}..."
-systemctl --user stop ${session_name} || echo "Fail stopping ${session_name}"
+log "01. Stopping existing ${session_name}..."
+systemctl --user stop ${session_name} || log "Fail stopping ${session_name}"
 
-echo "02. Downloading OpenAEV Agent into ${install_dir}..."
-(mkdir -p ${install_dir} && touch ${install_dir} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to ${install_dir}\n" >&2 && exit 1)
-curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent
-chmod +x ${install_dir}/openaev-agent
+log "02. Downloading OpenAEV Agent into ${install_dir}..."
+run mkdir -p "${install_dir}"
+[ -w "${install_dir}" ] || die "Can't write to ${install_dir}"
+run curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent
+run chmod +x ${install_dir}/openaev-agent
 
-echo "03. Creating OpenAEV configuration file"
-cat > ${install_dir}/openaev-agent-config.toml <<EOF
+log "03. Creating OpenAEV configuration file"
+cat > ${install_dir}/openaev-agent-config.toml <<EOF || die "Unable to write ${install_dir}/openaev-agent-config.toml"
 debug=false
 
 [openaev]
@@ -48,8 +52,8 @@ service_name = "${OPENAEV_SERVICE_NAME}"
 tenant_id = "${OPENAEV_TENANT_ID}"
 EOF
 
-echo "04. Writing agent service"
-cat > ${install_dir}/${session_name}.service <<EOF
+log "04. Writing agent service"
+cat > ${install_dir}/${session_name}.service <<EOF || die "Unable to write ${install_dir}/${session_name}.service"
 [Unit]
 Description=OpenAEV Agent Session
 After=network.target
@@ -61,13 +65,11 @@ StandardOutput=journal
 WantedBy=default.target
 EOF
 
-echo "05. Starting agent service"
-(
-  mkdir -p $systemd_unit_dir
-  ln -sf ${install_dir}/${session_name}.service $systemd_unit_dir
-  systemctl --user daemon-reload
-  systemctl --user enable ${session_name}
-  systemctl --user start ${session_name}
-) || (echo "Error while enabling OpenAEV Agent systemd unit file or starting the agent" >&2 && exit 1)
+log "05. Starting agent service"
+run mkdir -p $systemd_unit_dir
+run ln -sf ${install_dir}/${session_name}.service $systemd_unit_dir
+run systemctl --user daemon-reload
+run systemctl --user enable ${session_name}
+run systemctl --user start ${session_name}
 
-echo "OpenAEV Agent started."
+log "OpenAEV Agent started."

--- a/installer/linux/agent-installer.sh
+++ b/installer/linux/agent-installer.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 set -e
 
+log() { printf '%s\n' "$*" >&2; }
+die() { log "[ERROR] $*"; exit 1; }
+run() {
+  "$@" || die "$*"
+}
+
 base_url=${OPENAEV_URL}
-architecture=$(uname -m)
-systemd_status=$(systemctl is-system-running)
+architecture=$(run uname -m)
+systemd_status=$(systemctl is-system-running 2>/dev/null || true)
 
 os=$(uname | tr '[:upper:]' '[:lower:]')
 install_dir="${OPENAEV_INSTALL_DIR}"
@@ -11,29 +17,28 @@ service_name="${OPENAEV_SERVICE_NAME}"
 tenant_id="${OPENAEV_TENANT_ID}"
 
 if [ "${os}" != "linux" ]; then
-  echo "Operating system $OSTYPE is not supported yet, please create a ticket in openaev github project"
-  exit 1
+  die "Operating system $OSTYPE is not supported yet, please create a ticket in openaev github project"
 fi
 
 if [ "$systemd_status" != "running" ] && [ "$systemd_status" != "degraded" ]; then
-  echo "Systemd is in unexpected state: $systemd_status. Installation is not supported."
-  exit 1
+  die "Systemd is in unexpected state: $systemd_status. Installation is not supported."
 else
-  echo "Systemd is in acceptable state: $systemd_status"
+  log "Systemd is in acceptable state: $systemd_status"
 fi
 
-echo "Starting install script for ${os} | ${architecture}"
+log "Starting install script for ${os} | ${architecture}"
 
-echo "01. Stopping existing openaev-agent..."
-systemctl stop ${service_name} || echo "Fail stopping ${service_name}"
+log "01. Stopping existing openaev-agent..."
+systemctl stop ${service_name} || log "Fail stopping ${service_name}"
 
-echo "02. Downloading OpenAEV Agent into ${install_dir}..."
-(mkdir -p ${install_dir} && touch ${install_dir} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to ${install_dir}\n" >&2 && exit 1)
-curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent
-chmod 755 ${install_dir}/openaev-agent
+log "02. Downloading OpenAEV Agent into ${install_dir}..."
+run mkdir -p "${install_dir}"
+[ -w "${install_dir}" ] || die "Can't write to ${install_dir}"
+run curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent
+run chmod 755 ${install_dir}/openaev-agent
 
-echo "03. Creating OpenAEV configuration file"
-cat > ${install_dir}/openaev-agent-config.toml <<EOF
+log "03. Creating OpenAEV configuration file"
+cat > ${install_dir}/openaev-agent-config.toml <<EOF || die "Unable to write ${install_dir}/openaev-agent-config.toml"
 debug=false
 
 [openaev]
@@ -46,8 +51,8 @@ service_name = "${OPENAEV_SERVICE_NAME}"
 tenant_id = "${OPENAEV_TENANT_ID}"
 EOF
 
-echo "04. Writing agent service"
-cat > ${install_dir}/${service_name}.service <<EOF
+log "04. Writing agent service"
+cat > ${install_dir}/${service_name}.service <<EOF || die "Unable to write ${install_dir}/${session_name}.service"
 [Unit]
 Description=OpenAEV Agent
 After=network.target
@@ -61,12 +66,10 @@ RestartSec=60
 WantedBy=multi-user.target
 EOF
 
-echo "05. Starting agent service"
-(
-  ln -sf ${install_dir}/${service_name}.service /etc/systemd/system/
-  systemctl daemon-reload
-  systemctl enable ${service_name}
-  systemctl start ${service_name}
-) || (echo "Error while enabling OpenAEV Agent systemd unit file or starting the agent" >&2 && exit 1)
+log "05. Starting agent service"
+run ln -sf ${install_dir}/${service_name}.service /etc/systemd/system/
+run systemctl daemon-reload
+run systemctl enable ${service_name}
+run systemctl start ${service_name}
 
-echo "OpenAEV Agent started."
+log "OpenAEV Agent started."

--- a/installer/linux/agent-installer.sh
+++ b/installer/linux/agent-installer.sh
@@ -52,7 +52,7 @@ tenant_id = "${OPENAEV_TENANT_ID}"
 EOF
 
 log "04. Writing agent service"
-cat > ${install_dir}/${service_name}.service <<EOF || die "Unable to write ${install_dir}/${session_name}.service"
+cat > ${install_dir}/${service_name}.service <<EOF || die "Unable to write ${install_dir}/${service_name}.service"
 [Unit]
 Description=OpenAEV Agent
 After=network.target

--- a/installer/linux/agent-upgrade-service-user.sh
+++ b/installer/linux/agent-upgrade-service-user.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 set -e
 
+log() { printf '%s\n' "$*" >&2; }
+die() { log "[ERROR] $*"; exit 1; }
+run() {
+  "$@" || die "$*"
+}
+
 base_url=${OPENAEV_URL}
-architecture=$(uname -m)
-systemd_status=$(systemctl is-system-running)
+architecture=$(run uname -m)
+systemd_status=$(systemctl is-system-running 2>/dev/null || true)
 
 os=$(uname | tr '[:upper:]' '[:lower:]')
 session_name="${OPENAEV_SERVICE_NAME}"
@@ -22,26 +28,24 @@ case "${OPENAEV_INSTALL_DIR}" in
 esac
 
 if [ "${os}" != "linux" ]; then
-  echo "Operating system $OSTYPE is not supported yet, please create a ticket in openaev github project"
-  exit 1
+  die "Operating system $OSTYPE is not supported yet, please create a ticket in openaev github project"
 fi
 
 if [ "$systemd_status" != "running" ] && [ "$systemd_status" != "degraded" ]; then
-  echo "Systemd is in unexpected state: $systemd_status. Installation is not supported."
-  exit 1
+  die "Systemd is in unexpected state: $systemd_status. Installation is not supported."
 else
-  echo "Systemd is in acceptable state: $systemd_status"
+  log "Systemd is in acceptable state: $systemd_status"
 fi
 
-echo "Starting upgrade script for ${os} | ${architecture}"
+log "Starting upgrade script for ${os} | ${architecture}"
 
-echo "01. Downloading OpenAEV Agent into ${install_dir}..."
-curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent_upgrade
+log "01. Downloading OpenAEV Agent into ${install_dir}..."
+run curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent_upgrade
 mv ${install_dir}/openaev-agent_upgrade ${install_dir}/openaev-agent
-chmod +x ${install_dir}/openaev-agent
+run chmod +x ${install_dir}/openaev-agent
 
-echo "02. Updating OpenAEV configuration file"
-cat > ${install_dir}/openaev-agent-config.toml <<EOF
+log "02. Updating OpenAEV configuration file"
+cat > ${install_dir}/openaev-agent-config.toml <<EOF || die "Unable to write ${install_dir}/openaev-agent-config.toml"
 debug=false
 
 [openaev]
@@ -54,7 +58,7 @@ service_name = "${OPENAEV_SERVICE_NAME}"
 tenant_id = "${OPENAEV_TENANT_ID}"
 EOF
 
-echo "03. Restarting the service"
-systemctl --user restart ${session_name} || (echo "Fail restarting ${session_name}" >&2 && exit 1)
+log "03. Restarting the service"
+run systemctl --user restart ${session_name}
 
-echo "OpenAEV Agent Session User started."
+log "OpenAEV Agent Session User started."

--- a/installer/linux/agent-upgrade-session-user.sh
+++ b/installer/linux/agent-upgrade-session-user.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 set -e
 
+log() { printf '%s\n' "$*" >&2; }
+die() { log "[ERROR] $*"; exit 1; }
+run() {
+  "$@" || die "$*"
+}
+
 base_url=${OPENAEV_URL}
-architecture=$(uname -m)
-systemd_status=$(systemctl is-system-running)
+architecture=$(run uname -m)
+systemd_status=$(systemctl is-system-running 2>/dev/null || true)
 
 os=$(uname | tr '[:upper:]' '[:lower:]')
 session_name="${OPENAEV_SERVICE_NAME}"
@@ -22,31 +28,29 @@ case "${OPENAEV_INSTALL_DIR}" in
 esac
 
 if [ "${os}" != "linux" ]; then
-  echo "Operating system $OSTYPE is not supported yet, please create a ticket in openaev github project"
-  exit 1
+  die "Operating system $OSTYPE is not supported yet, please create a ticket in openaev github project"
 fi
 
 if [ "$systemd_status" != "running" ] && [ "$systemd_status" != "degraded" ]; then
-  echo "Systemd is in unexpected state: $systemd_status. Installation is not supported."
-  exit 1
+  die "Systemd is in unexpected state: $systemd_status. Installation is not supported."
 else
-  echo "Systemd is in acceptable state: $systemd_status"
+  log "Systemd is in acceptable state: $systemd_status"
 fi
 
-echo "Starting upgrade script for ${os} | ${architecture}"
+log "Starting upgrade script for ${os} | ${architecture}"
 
 # Manage the renaming OpenBAS -> OpenAEV ...
 openaev_dir=$(printf %s "${install_dir}" | sed 's/openbas/openaev/g')
 if [ -d "$openaev_dir" ]; then
 # Upgrade the agent if the folder *openaev* exists
 
-echo "01. Downloading OpenAEV Agent into ${install_dir}..."
-curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent_upgrade
+log "01. Downloading OpenAEV Agent into ${install_dir}..."
+run curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent_upgrade
 mv ${install_dir}/openaev-agent_upgrade ${install_dir}/openaev-agent
-chmod +x ${install_dir}/openaev-agent
+run chmod +x ${install_dir}/openaev-agent
 
-echo "02. Updating OpenAEV configuration file"
-cat > ${install_dir}/openaev-agent-config.toml <<EOF
+log "02. Updating OpenAEV configuration file"
+cat > ${install_dir}/openaev-agent-config.toml <<EOF || die "Unable to write ${install_dir}/openaev-agent-config.toml"
 debug=false
 
 [openaev]
@@ -59,25 +63,23 @@ service_name = "${OPENAEV_SERVICE_NAME}"
 tenant_id = "${OPENAEV_TENANT_ID}"
 EOF
 
-echo "03. Restarting the service"
-systemctl --user restart ${session_name} || (echo "Fail restarting ${session_name}" >&2 && exit 1)
+log "03. Restarting the service"
+run systemctl --user restart ${session_name}
 
 else
 # Uninstall the old named agent *openbas* and install the new named agent *openaev* if the folder openaev doesn't exist
-echo "01. Installing OpenAEV Agent..."
+log "01. Installing OpenAEV Agent..."
 openaev_session=$(printf %s "${session_name}" | sed 's/openbas/openaev/g')
-curl -sSfLG ${base_url}/api/tenants/${tenant_id}/agent/installer/openaev/${os}/session-user/${OPENAEV_TOKEN} --data-urlencode "installationDir=${openaev_dir}" --data-urlencode "serviceName=${openaev_session}" | sh
+run curl -sSfLG ${base_url}/api/tenants/${tenant_id}/agent/installer/openaev/${os}/session-user/${OPENAEV_TOKEN} --data-urlencode "installationDir=${openaev_dir}" --data-urlencode "serviceName=${openaev_session}" | sh
 
-echo "02. Uninstalling OpenBAS Agent..."
-(
+log "02. Uninstalling OpenBAS Agent..."
 uninstall_dir=$(printf %s "${install_dir}" | sed 's/openaev/openbas/g')
 uninstall_session=$(printf %s "${session_name}" | sed 's/openaev/openbas/g')
-rm -f ${uninstall_dir}/openbas_agent_kill.sh
-rm -f ${uninstall_dir}/openbas-agent-config.toml
-rm -f ${uninstall_dir}/openbas-agent
-systemctl --user disable ${uninstall_session} --now
-) || (echo "Error while uninstalling OpenBAS Agent" >&2 && exit 1)
+run rm -f ${uninstall_dir}/openbas_agent_kill.sh
+run rm -f ${uninstall_dir}/openbas-agent-config.toml
+run rm -f ${uninstall_dir}/openbas-agent
+run systemctl --user disable ${uninstall_session} --now
 fi
 # ... Manage the renaming OpenBAS -> OpenAEV
 
-echo "OpenAEV Agent Session User started."
+log "OpenAEV Agent Session User started."

--- a/installer/linux/agent-upgrade-session-user.sh
+++ b/installer/linux/agent-upgrade-session-user.sh
@@ -70,7 +70,10 @@ else
 # Uninstall the old named agent *openbas* and install the new named agent *openaev* if the folder openaev doesn't exist
 log "01. Installing OpenAEV Agent..."
 openaev_session=$(printf %s "${session_name}" | sed 's/openbas/openaev/g')
-run curl -sSfLG ${base_url}/api/tenants/${tenant_id}/agent/installer/openaev/${os}/session-user/${OPENAEV_TOKEN} --data-urlencode "installationDir=${openaev_dir}" --data-urlencode "serviceName=${openaev_session}" | sh
+tmp_installer="$(mktemp)" || die "mktemp failed"
+run curl -sSfLG ${base_url}/api/tenants/${tenant_id}/agent/installer/openaev/${os}/session-user/${OPENAEV_TOKEN} --data-urlencode "installationDir=${openaev_dir}" --data-urlencode "serviceName=${openaev_session}" -o "$tmp_installer"
+run sh "$tmp_installer"
+rm -f "$tmp_installer"
 
 log "02. Uninstalling OpenBAS Agent..."
 uninstall_dir=$(printf %s "${install_dir}" | sed 's/openaev/openbas/g')

--- a/installer/linux/agent-upgrade.sh
+++ b/installer/linux/agent-upgrade.sh
@@ -60,11 +60,14 @@ else
 # Uninstall the old named agent *openbas* and install the new named agent *openaev* if the folder openaev doesn't exist
 log "01. Installing OpenAEV Agent..."
 openaev_service=$(printf %s "${service_name}" | sed 's/openbas/openaev/g')
-run curl -sSfLG ${base_url}/api/tenants/${tenant_id}/agent/installer/openaev/${os}/service/${OPENAEV_TOKEN} --data-urlencode "installationDir=${openaev_dir}" --data-urlencode "serviceName=${openaev_service}" | sh
+tmp_installer="$(mktemp)" || die "mktemp failed"
+run curl -sSfLG ${base_url}/api/tenants/${tenant_id}/agent/installer/openaev/${os}/service/${OPENAEV_TOKEN} --data-urlencode "installationDir=${openaev_dir}" --data-urlencode "serviceName=${openaev_service}" -o "$tmp_installer"
+run sh "$tmp_installer"
+rm -f "$tmp_installer"
 
 log "02. Uninstalling OpenBAS Agent..."
-run uninstall_dir=$(printf %s "${install_dir}" | sed 's/openaev/openbas/g')
-run uninstall_service=$(printf %s "${service_name}" | sed 's/openaev/openbas/g')
+uninstall_dir=$(printf %s "${install_dir}" | sed 's/openaev/openbas/g')
+uninstall_service=$(printf %s "${service_name}" | sed 's/openaev/openbas/g')
 run rm -f ${uninstall_dir}/openbas_agent_kill.sh
 run rm -f ${uninstall_dir}/openbas-agent-config.toml
 run rm -f ${uninstall_dir}/openbas-agent

--- a/installer/linux/agent-upgrade.sh
+++ b/installer/linux/agent-upgrade.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 set -e
 
+log() { printf '%s\n' "$*" >&2; }
+die() { log "[ERROR] $*"; exit 1; }
+run() {
+  "$@" || die "$*"
+}
+
 base_url=${OPENAEV_URL}
-architecture=$(uname -m)
-systemd_status=$(systemctl is-system-running)
+architecture=$(run uname -m)
+systemd_status=$(systemctl is-system-running 2>/dev/null || true)
 
 os=$(uname | tr '[:upper:]' '[:lower:]')
 install_dir="${OPENAEV_INSTALL_DIR}"
@@ -11,31 +17,29 @@ service_name="${OPENAEV_SERVICE_NAME}"
 tenant_id="${OPENAEV_TENANT_ID}"
 
 if [ "${os}" != "linux" ]; then
-  echo "Operating system ${os} is not supported yet, please create a ticket in openaev github project"
-  exit 1
+  die "Operating system ${os} is not supported yet, please create a ticket in openaev github project"
 fi
 
 if [ "$systemd_status" != "running" ] && [ "$systemd_status" != "degraded" ]; then
-  echo "Systemd is in unexpected state: $systemd_status. Installation is not supported."
-  exit 1
+  die "Systemd is in unexpected state: $systemd_status. Installation is not supported."
 else
-  echo "Systemd is in acceptable state: $systemd_status"
+  log "Systemd is in acceptable state: $systemd_status"
 fi
 
-echo "Starting upgrade script for ${os} | ${architecture}"
+log "Starting upgrade script for ${os} | ${architecture}"
 
 # Manage the renaming OpenBAS -> OpenAEV ...
 openaev_dir=$(printf %s "${install_dir}" | sed 's/openbas/openaev/g')
 if [ -d "$openaev_dir" ]; then
 # Upgrade the agent if the folder *openaev* exists
 
-echo "01. Downloading OpenAEV Agent into ${install_dir}..."
-curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent_upgrade
+log "01. Downloading OpenAEV Agent into ${install_dir}..."
+run curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent_upgrade
 mv ${install_dir}/openaev-agent_upgrade ${install_dir}/openaev-agent
-chmod 755 ${install_dir}/openaev-agent
+run chmod 755 ${install_dir}/openaev-agent
 
-echo "02. Updating OpenAEV configuration file"
-cat > ${install_dir}/openaev-agent-config.toml <<EOF
+log "02. Updating OpenAEV configuration file"
+cat > ${install_dir}/openaev-agent-config.toml <<EOF || die "Unable to write ${install_dir}/openaev-agent-config.toml"
 
 debug=false
 
@@ -49,26 +53,24 @@ service_name = "${OPENAEV_SERVICE_NAME}"
 tenant_id = "${OPENAEV_TENANT_ID}"
 EOF
 
-echo "03. Restarting the service"
-systemctl restart ${service_name} || (echo "Fail restarting ${service_name}" >&2 && exit 1)
+log "03. Restarting the service"
+systemctl restart ${service_name} || die "Fail restarting ${service_name}"
 
 else
 # Uninstall the old named agent *openbas* and install the new named agent *openaev* if the folder openaev doesn't exist
-echo "01. Installing OpenAEV Agent..."
+log "01. Installing OpenAEV Agent..."
 openaev_service=$(printf %s "${service_name}" | sed 's/openbas/openaev/g')
-curl -sSfLG ${base_url}/api/tenants/${tenant_id}/agent/installer/openaev/${os}/service/${OPENAEV_TOKEN} --data-urlencode "installationDir=${openaev_dir}" --data-urlencode "serviceName=${openaev_service}" | sh
+run curl -sSfLG ${base_url}/api/tenants/${tenant_id}/agent/installer/openaev/${os}/service/${OPENAEV_TOKEN} --data-urlencode "installationDir=${openaev_dir}" --data-urlencode "serviceName=${openaev_service}" | sh
 
-echo "02. Uninstalling OpenBAS Agent..."
-(
-uninstall_dir=$(printf %s "${install_dir}" | sed 's/openaev/openbas/g')
-uninstall_service=$(printf %s "${service_name}" | sed 's/openaev/openbas/g')
-rm -f ${uninstall_dir}/openbas_agent_kill.sh
-rm -f ${uninstall_dir}/openbas-agent-config.toml
-rm -f ${uninstall_dir}/openbas-agent
-systemctl disable ${uninstall_service} --now
-) || (echo "Error while uninstalling OpenBAS Agent" >&2 && exit 1)
+log "02. Uninstalling OpenBAS Agent..."
+run uninstall_dir=$(printf %s "${install_dir}" | sed 's/openaev/openbas/g')
+run uninstall_service=$(printf %s "${service_name}" | sed 's/openaev/openbas/g')
+run rm -f ${uninstall_dir}/openbas_agent_kill.sh
+run rm -f ${uninstall_dir}/openbas-agent-config.toml
+run rm -f ${uninstall_dir}/openbas-agent
+run systemctl disable ${uninstall_service} --now
 
 fi
 # ... Manage the renaming OpenBAS -> OpenAEV
 
-echo "OpenAEV Agent started."
+log "OpenAEV Agent started."


### PR DESCRIPTION
### Problem Information :
systemctl is-system-running returns a non-zero exit code for any state other than running (e.g. degraded → exit code 1). Combined with set -e, this causes the script to exit immediately, even though degraded is an acceptable state. 
Moreover, the script exits silently without any details about what failed

### Proposed changes

* Capture the systemd state without triggering set -e:
`systemd_status=$(systemctl is-system-running 2>/dev/null || true)`
Then explicitly handle each state — accepting running and degraded, otherwise stopping the script with a clear error message.
* Improve error handling by introducing two helpers:
      -  run() — wraps any command and calls die on failure
      -  die() — logs the exact command that failed and exits

### Testing Instructions

1. Use linux machine where systemd is degraded 
    - to check systemd status : `systemctl is-system-running`    
2. install openaev agent
3. the installation should work

### Related issues

* Closes #[5871](https://github.com/OpenAEV-Platform/openaev/issues/5871)