### PR TITLE
feat(asset): report HOST asset category on registration

### DIFF
--- a/src/api/register_agent.rs
+++ b/src/api/register_agent.rs
@@ -96,6 +96,7 @@ impl Client {
         let post_data = json!({
           "asset_name": hostname::get()?.to_string_lossy(),
           "asset_external_reference": asset_external_reference,
+          "asset_category": "HOST",
           "endpoint_agent_version": VERSION,
           "endpoint_ips": ip_addresses,
           "endpoint_platform": get_operating_system(),


### PR DESCRIPTION
Send asset_category=HOST on agent endpoint registration so agent-managed machines are classified under the new asset taxonomy. Dependency of OpenAEV-Platform/openaev#6452.