### PR TITLE
feat(asset): report HOST category and send asset-scoped network fields on registration (#207)

### DIFF
--- a/src/api/register_agent.rs
+++ b/src/api/register_agent.rs
@@ -98,11 +98,13 @@ impl Client {
           "asset_external_reference": asset_external_reference,
           "asset_category": "HOST",
           "endpoint_agent_version": VERSION,
-          "endpoint_ips": ip_addresses,
+          // Network fields moved from the endpoint to the asset level in the asset taxonomy
+          // remodel; platform / arch / agent_version stay endpoint-scoped (agent-capable hosts).
+          "asset_ips": ip_addresses,
           "endpoint_platform": get_operating_system(),
           "endpoint_arch": get_arch(),
-          "endpoint_mac_addresses": mac_addresses,
-          "endpoint_hostname": hostname::get()?.to_string_lossy(),
+          "asset_mac_addresses": mac_addresses,
+          "asset_hostname": hostname::get()?.to_string_lossy(),
           "agent_is_service": is_service,
           "agent_is_elevated": is_elevated,
           "agent_executed_by_user": executed_by_user,

--- a/src/api/register_agent.rs
+++ b/src/api/register_agent.rs
@@ -93,18 +93,20 @@ impl Client {
             Error::Internal(e.to_string())
         })?;
 
+        let hostname = hostname::get()?.to_string_lossy().into_owned();
+
+        // Network fields moved from the endpoint to the asset level in the asset taxonomy
+        // remodel; platform / arch / agent_version stay endpoint-scoped (agent-capable hosts).
         let post_data = json!({
-          "asset_name": hostname::get()?.to_string_lossy(),
+          "asset_name": hostname,
           "asset_external_reference": asset_external_reference,
           "asset_category": "HOST",
-          "endpoint_agent_version": VERSION,
-          // Network fields moved from the endpoint to the asset level in the asset taxonomy
-          // remodel; platform / arch / agent_version stay endpoint-scoped (agent-capable hosts).
+          "asset_hostname": hostname,
           "asset_ips": ip_addresses,
+          "asset_mac_addresses": mac_addresses,
+          "endpoint_agent_version": VERSION,
           "endpoint_platform": get_operating_system(),
           "endpoint_arch": get_arch(),
-          "asset_mac_addresses": mac_addresses,
-          "asset_hostname": hostname::get()?.to_string_lossy(),
           "agent_is_service": is_service,
           "agent_is_elevated": is_elevated,
           "agent_executed_by_user": executed_by_user,


### PR DESCRIPTION
## Summary

Adapts the agent registration payload to the OpenAEV asset taxonomy remodel:

- Network fields renamed to the asset level: endpoint_ips -> asset_ips, endpoint_hostname -> asset_hostname, endpoint_mac_addresses -> asset_mac_addresses.
- Platform / arch / agent_version stay endpoint-scoped; asset_name / asset_external_reference / asset_category (HOST) are asset_*.
- The hostname is now computed once and reused for asset_name and asset_hostname (review feedback: avoids a redundant syscall and any inconsistency between the two fields), and the payload keys are grouped by scope (asset_*, endpoint_*, agent_*) for readability. Wire format unchanged.

The backend keeps a JsonAlias on the legacy endpoint_* names so already-deployed agents keep registering until they self-update; this aligns the agent source with the new canonical wire names used by the platform, injectors, collectors and the Python client.

The implant needs no change (it sends no endpoint_* asset fields).

Closes #207

## Test plan

- [x] CI green on all platforms (fmt, audit, clippy on ubuntu/windows/macos, tests and builds on all six targets, coverage, installer script packaging).
- [ ] Build the agent and register against an OpenAEV backend that includes the asset taxonomy remodel; confirm the endpoint is created with hostname / IPs / MAC addresses populated.
