### PR TITLE
fix(ci): switch Codecov upload from OIDC to token authentication

### DIFF
--- a/.github/workflows/agent-ci.yml
+++ b/.github/workflows/agent-ci.yml
@@ -197,7 +197,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -232,7 +231,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@v7
         with:
-          use_oidc: true
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           flags: agent
           disable_search: true


### PR DESCRIPTION
## Summary

- Replace `use_oidc: true` with `token: ${{ secrets.CODECOV_TOKEN }}` in the coverage upload step
- Remove `id-token: write` permission (no longer needed)

OIDC authentication is not configured on the Codecov organization. This switches to token-based authentication, aligned with how openaev handles Codecov uploads.

**Prerequisite:** the `CODECOV_TOKEN` secret must be set at the org or repo level.