### PR TITLE
fix(installer): honor unsecured certificate flag in installer download steps (#3924)

### DIFF
--- a/installer/linux/agent-installer-service-user.sh
+++ b/installer/linux/agent-installer-service-user.sh
@@ -50,6 +50,13 @@ fi
 
 base_url=${OPENAEV_URL}
 architecture=$(uname -m)
+
+# Skip TLS certificate validation only when the platform explicitly runs with
+# an unsecured (e.g. self-signed) certificate
+curl_insecure=""
+if [ "${OPENAEV_UNSECURED_CERTIFICATE}" = "true" ]; then
+  curl_insecure="-k"
+fi
 user="$USER_ARG"
 group="$GROUP_ARG"
 
@@ -83,7 +90,7 @@ systemctl stop ${service_name} || log "Fail stopping ${service_name}"
 log "02. Downloading OpenAEV Agent into ${install_dir}..."
 run mkdir -p "${install_dir}"
 [ -w "${install_dir}" ] || die "Can't write to ${install_dir}"
-run curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent
+run curl -sSfL ${curl_insecure} ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent
 run chmod +x ${install_dir}/openaev-agent
 
 log "03. Creating OpenAEV configuration file"

--- a/installer/linux/agent-installer-session-user.sh
+++ b/installer/linux/agent-installer-session-user.sh
@@ -9,6 +9,13 @@ run() {
 
 base_url=${OPENAEV_URL}
 architecture=$(run uname -m)
+
+# Skip TLS certificate validation only when the platform explicitly runs with
+# an unsecured (e.g. self-signed) certificate
+curl_insecure=""
+if [ "${OPENAEV_UNSECURED_CERTIFICATE}" = "true" ]; then
+  curl_insecure="-k"
+fi
 systemd_status=$(systemctl is-system-running 2>/dev/null || true)
 
 os=$(uname | tr '[:upper:]' '[:lower:]')
@@ -35,7 +42,7 @@ systemctl --user stop ${session_name} || log "Fail stopping ${session_name}"
 log "02. Downloading OpenAEV Agent into ${install_dir}..."
 run mkdir -p "${install_dir}"
 [ -w "${install_dir}" ] || die "Can't write to ${install_dir}"
-run curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent
+run curl -sSfL ${curl_insecure} ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent
 run chmod +x ${install_dir}/openaev-agent
 
 log "03. Creating OpenAEV configuration file"

--- a/installer/linux/agent-installer.sh
+++ b/installer/linux/agent-installer.sh
@@ -9,6 +9,13 @@ run() {
 
 base_url=${OPENAEV_URL}
 architecture=$(run uname -m)
+
+# Skip TLS certificate validation only when the platform explicitly runs with
+# an unsecured (e.g. self-signed) certificate
+curl_insecure=""
+if [ "${OPENAEV_UNSECURED_CERTIFICATE}" = "true" ]; then
+  curl_insecure="-k"
+fi
 systemd_status=$(systemctl is-system-running 2>/dev/null || true)
 
 os=$(uname | tr '[:upper:]' '[:lower:]')
@@ -34,7 +41,7 @@ systemctl stop ${service_name} || log "Fail stopping ${service_name}"
 log "02. Downloading OpenAEV Agent into ${install_dir}..."
 run mkdir -p "${install_dir}"
 [ -w "${install_dir}" ] || die "Can't write to ${install_dir}"
-run curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent
+run curl -sSfL ${curl_insecure} ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent
 run chmod 755 ${install_dir}/openaev-agent
 
 log "03. Creating OpenAEV configuration file"

--- a/installer/linux/agent-upgrade-service-user.sh
+++ b/installer/linux/agent-upgrade-service-user.sh
@@ -9,6 +9,13 @@ run() {
 
 base_url=${OPENAEV_URL}
 architecture=$(run uname -m)
+
+# Skip TLS certificate validation only when the platform explicitly runs with
+# an unsecured (e.g. self-signed) certificate
+curl_insecure=""
+if [ "${OPENAEV_UNSECURED_CERTIFICATE}" = "true" ]; then
+  curl_insecure="-k"
+fi
 systemd_status=$(systemctl is-system-running 2>/dev/null || true)
 
 os=$(uname | tr '[:upper:]' '[:lower:]')
@@ -40,7 +47,7 @@ fi
 log "Starting upgrade script for ${os} | ${architecture}"
 
 log "01. Downloading OpenAEV Agent into ${install_dir}..."
-run curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent_upgrade
+run curl -sSfL ${curl_insecure} ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent_upgrade
 mv ${install_dir}/openaev-agent_upgrade ${install_dir}/openaev-agent
 run chmod +x ${install_dir}/openaev-agent
 

--- a/installer/linux/agent-upgrade-session-user.sh
+++ b/installer/linux/agent-upgrade-session-user.sh
@@ -9,6 +9,13 @@ run() {
 
 base_url=${OPENAEV_URL}
 architecture=$(run uname -m)
+
+# Skip TLS certificate validation only when the platform explicitly runs with
+# an unsecured (e.g. self-signed) certificate
+curl_insecure=""
+if [ "${OPENAEV_UNSECURED_CERTIFICATE}" = "true" ]; then
+  curl_insecure="-k"
+fi
 systemd_status=$(systemctl is-system-running 2>/dev/null || true)
 
 os=$(uname | tr '[:upper:]' '[:lower:]')
@@ -45,7 +52,7 @@ if [ -d "$openaev_dir" ]; then
 # Upgrade the agent if the folder *openaev* exists
 
 log "01. Downloading OpenAEV Agent into ${install_dir}..."
-run curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent_upgrade
+run curl -sSfL ${curl_insecure} ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent_upgrade
 mv ${install_dir}/openaev-agent_upgrade ${install_dir}/openaev-agent
 run chmod +x ${install_dir}/openaev-agent
 
@@ -71,7 +78,7 @@ else
 log "01. Installing OpenAEV Agent..."
 openaev_session=$(printf %s "${session_name}" | sed 's/openbas/openaev/g')
 tmp_installer="$(mktemp)" || die "mktemp failed"
-run curl -sSfLG ${base_url}/api/tenants/${tenant_id}/agent/installer/openaev/${os}/session-user/${OPENAEV_TOKEN} --data-urlencode "installationDir=${openaev_dir}" --data-urlencode "serviceName=${openaev_session}" -o "$tmp_installer"
+run curl -sSfLG ${curl_insecure} ${base_url}/api/tenants/${tenant_id}/agent/installer/openaev/${os}/session-user/${OPENAEV_TOKEN} --data-urlencode "installationDir=${openaev_dir}" --data-urlencode "serviceName=${openaev_session}" -o "$tmp_installer"
 run sh "$tmp_installer"
 rm -f "$tmp_installer"
 

--- a/installer/linux/agent-upgrade.sh
+++ b/installer/linux/agent-upgrade.sh
@@ -9,6 +9,13 @@ run() {
 
 base_url=${OPENAEV_URL}
 architecture=$(run uname -m)
+
+# Skip TLS certificate validation only when the platform explicitly runs with
+# an unsecured (e.g. self-signed) certificate
+curl_insecure=""
+if [ "${OPENAEV_UNSECURED_CERTIFICATE}" = "true" ]; then
+  curl_insecure="-k"
+fi
 systemd_status=$(systemctl is-system-running 2>/dev/null || true)
 
 os=$(uname | tr '[:upper:]' '[:lower:]')
@@ -34,7 +41,7 @@ if [ -d "$openaev_dir" ]; then
 # Upgrade the agent if the folder *openaev* exists
 
 log "01. Downloading OpenAEV Agent into ${install_dir}..."
-run curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent_upgrade
+run curl -sSfL ${curl_insecure} ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent_upgrade
 mv ${install_dir}/openaev-agent_upgrade ${install_dir}/openaev-agent
 run chmod 755 ${install_dir}/openaev-agent
 
@@ -61,7 +68,7 @@ else
 log "01. Installing OpenAEV Agent..."
 openaev_service=$(printf %s "${service_name}" | sed 's/openbas/openaev/g')
 tmp_installer="$(mktemp)" || die "mktemp failed"
-run curl -sSfLG ${base_url}/api/tenants/${tenant_id}/agent/installer/openaev/${os}/service/${OPENAEV_TOKEN} --data-urlencode "installationDir=${openaev_dir}" --data-urlencode "serviceName=${openaev_service}" -o "$tmp_installer"
+run curl -sSfLG ${curl_insecure} ${base_url}/api/tenants/${tenant_id}/agent/installer/openaev/${os}/service/${OPENAEV_TOKEN} --data-urlencode "installationDir=${openaev_dir}" --data-urlencode "serviceName=${openaev_service}" -o "$tmp_installer"
 run sh "$tmp_installer"
 rm -f "$tmp_installer"
 

--- a/installer/macos/agent-installer-service-user.sh
+++ b/installer/macos/agent-installer-service-user.sh
@@ -48,6 +48,13 @@ fi
 
 base_url=${OPENAEV_URL}
 architecture=$(uname -m)
+
+# Skip TLS certificate validation only when the platform explicitly runs with
+# an unsecured (e.g. self-signed) certificate
+curl_insecure=""
+if [ "${OPENAEV_UNSECURED_CERTIFICATE}" = "true" ]; then
+  curl_insecure="-k"
+fi
 user="$USER_ARG"
 group="$GROUP_ARG"
 uid=$(id -u ${user})
@@ -73,7 +80,7 @@ launchctl bootout gui/${uid} /Library/LaunchAgents/${service_name}.plist || echo
 
 echo "02. Downloading OpenAEV Agent into ${install_dir}..."
 (mkdir -p ${install_dir} && touch ${install_dir} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to ${install_dir}\n" >&2 && exit 1)
-curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent
+curl -sSfL ${curl_insecure} ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent
 chmod +x ${install_dir}/openaev-agent
 
 echo "03. Creating OpenAEV configuration file"

--- a/installer/macos/agent-installer-session-user.sh
+++ b/installer/macos/agent-installer-session-user.sh
@@ -4,6 +4,13 @@ set -e
 base_url=${OPENAEV_URL}
 architecture=$(uname -m)
 
+# Skip TLS certificate validation only when the platform explicitly runs with
+# an unsecured (e.g. self-signed) certificate
+curl_insecure=""
+if [ "${OPENAEV_UNSECURED_CERTIFICATE}" = "true" ]; then
+  curl_insecure="-k"
+fi
+
 install_dir="/Users/$(id -un)/${OPENAEV_INSTALL_DIR}"
 session_name="${OPENAEV_SERVICE_NAME}"
 tenant_id="${OPENAEV_TENANT_ID}"
@@ -25,7 +32,7 @@ launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/${session_name}.plist || e
 
 echo "02. Downloading OpenAEV Agent into ${install_dir}..."
 (mkdir -p ${install_dir} && touch ${install_dir} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to ${install_dir}\n" >&2 && exit 1)
-curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent
+curl -sSfL ${curl_insecure} ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent
 chmod +x ${install_dir}/openaev-agent
 
 echo "03. Creating OpenAEV configuration file"

--- a/installer/macos/agent-installer.sh
+++ b/installer/macos/agent-installer.sh
@@ -4,6 +4,13 @@ set -e
 base_url=${OPENAEV_URL}
 architecture=$(uname -m)
 
+# Skip TLS certificate validation only when the platform explicitly runs with
+# an unsecured (e.g. self-signed) certificate
+curl_insecure=""
+if [ "${OPENAEV_UNSECURED_CERTIFICATE}" = "true" ]; then
+  curl_insecure="-k"
+fi
+
 install_dir="${OPENAEV_INSTALL_DIR}"
 service_name="${OPENAEV_SERVICE_NAME}"
 tenant_id="${OPENAEV_TENANT_ID}"
@@ -25,7 +32,7 @@ launchctl bootout system /Library/LaunchDaemons/io.filigran.${service_name}.plis
 
 echo "02. Downloading OpenAEV Agent into ${install_dir}..."
 (mkdir -p ${install_dir} && touch ${install_dir} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to ${install_dir}\n" >&2 && exit 1)
-curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent
+curl -sSfL ${curl_insecure} ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent
 chmod 755 ${install_dir}/openaev-agent
 
 echo "03. Creating OpenAEV configuration file"

--- a/installer/macos/agent-upgrade-service-user.sh
+++ b/installer/macos/agent-upgrade-service-user.sh
@@ -3,6 +3,13 @@ set -e
 
 base_url=${OPENAEV_URL}
 architecture=$(uname -m)
+
+# Skip TLS certificate validation only when the platform explicitly runs with
+# an unsecured (e.g. self-signed) certificate
+curl_insecure=""
+if [ "${OPENAEV_UNSECURED_CERTIFICATE}" = "true" ]; then
+  curl_insecure="-k"
+fi
 user="$(id -un)"
 group="$(id -gn)"
 
@@ -23,7 +30,7 @@ echo "Starting upgrade script for ${os} | ${architecture}"
 
 echo "01. Downloading OpenAEV Agent into ${install_dir}..."
 (mkdir -p ${install_dir} && touch ${install_dir} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to ${install_dir}\n" >&2 && exit 1)
-curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent_upgrade
+curl -sSfL ${curl_insecure} ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent_upgrade
 mv ${install_dir}/openaev-agent_upgrade ${install_dir}/openaev-agent
 chmod +x ${install_dir}/openaev-agent
 

--- a/installer/macos/agent-upgrade-session-user.sh
+++ b/installer/macos/agent-upgrade-session-user.sh
@@ -4,6 +4,13 @@ set -e
 base_url=${OPENAEV_URL}
 architecture=$(uname -m)
 
+# Skip TLS certificate validation only when the platform explicitly runs with
+# an unsecured (e.g. self-signed) certificate
+curl_insecure=""
+if [ "${OPENAEV_UNSECURED_CERTIFICATE}" = "true" ]; then
+  curl_insecure="-k"
+fi
+
 install_dir="${OPENAEV_INSTALL_DIR}"
 session_name="${OPENAEV_SERVICE_NAME}"
 tenant_id="${OPENAEV_TENANT_ID}"
@@ -26,7 +33,7 @@ if [ -d "$openaev_dir" ]; then
 # Upgrade the agent if the folder *openaev* exists
 
 echo "01. Downloading OpenAEV Agent into ${install_dir}..."
-curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent_upgrade
+curl -sSfL ${curl_insecure} ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent_upgrade
 mv ${install_dir}/openaev-agent_upgrade ${install_dir}/openaev-agent
 chmod +x ${install_dir}/openaev-agent
 
@@ -52,7 +59,7 @@ else
 # Uninstall the old named agent *openbas* and install the new named agent *openaev* if the folder openaev doesn't exist
 echo "01. Installing OpenAEV Agent..."
 openaev_session=$(printf %s "${session_name}" | sed 's/openbas/openaev/g')
-curl -sSfLG ${base_url}/api/tenants/${tenant_id}/agent/installer/openaev/${os}/session-user/${OPENAEV_TOKEN} --data-urlencode "installationDir=${openaev_dir}" --data-urlencode "serviceName=${openaev_session}" | sh
+curl -sSfLG ${curl_insecure} ${base_url}/api/tenants/${tenant_id}/agent/installer/openaev/${os}/session-user/${OPENAEV_TOKEN} --data-urlencode "installationDir=${openaev_dir}" --data-urlencode "serviceName=${openaev_session}" | sh
 
 echo "02. Uninstalling OpenBAS Agent..."
 (

--- a/installer/macos/agent-upgrade.sh
+++ b/installer/macos/agent-upgrade.sh
@@ -4,6 +4,13 @@ set -e
 base_url=${OPENAEV_URL}
 architecture=$(uname -m)
 
+# Skip TLS certificate validation only when the platform explicitly runs with
+# an unsecured (e.g. self-signed) certificate
+curl_insecure=""
+if [ "${OPENAEV_UNSECURED_CERTIFICATE}" = "true" ]; then
+  curl_insecure="-k"
+fi
+
 install_dir="${OPENAEV_INSTALL_DIR}"
 service_name="${OPENAEV_SERVICE_NAME}"
 tenant_id="${OPENAEV_TENANT_ID}"
@@ -27,7 +34,7 @@ if [ -d "$openaev_dir" ]; then
 
 echo "01. Downloading OpenAEV Agent into ${install_dir}..."
 (mkdir -p ${install_dir} && touch ${install_dir} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to ${install_dir}\n" >&2 && exit 1)
-curl -sSfL ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent_upgrade
+curl -sSfL ${curl_insecure} ${base_url}/api/tenants/${tenant_id}/agent/executable/openaev/${os}/${architecture} -o ${install_dir}/openaev-agent_upgrade
 mv ${install_dir}/openaev-agent_upgrade ${install_dir}/openaev-agent
 chmod 755 ${install_dir}/openaev-agent
 
@@ -53,7 +60,7 @@ else
 # Uninstall the old named agent *openbas* and install the new named agent *openaev* if the folder openaev doesn't exist
 echo "01. Installing OpenAEV Agent..."
 openaev_service=$(printf %s "${service_name}" | sed 's/openbas/openaev/g')
-curl -sSfLG ${base_url}/api/tenants/${tenant_id}/agent/installer/openaev/${os}/service/${OPENAEV_TOKEN} --data-urlencode "installationDir=${openaev_dir}" --data-urlencode "serviceName=${openaev_service}" | sh
+curl -sSfLG ${curl_insecure} ${base_url}/api/tenants/${tenant_id}/agent/installer/openaev/${os}/service/${OPENAEV_TOKEN} --data-urlencode "installationDir=${openaev_dir}" --data-urlencode "serviceName=${openaev_service}" | sh
 
 echo "02. Uninstalling OpenBAS Agent..."
 (

--- a/installer/windows/agent-installer-service-user.ps1
+++ b/installer/windows/agent-installer-service-user.ps1
@@ -75,6 +75,12 @@ switch ($env:PROCESSOR_ARCHITECTURE)
 if ([string]::IsNullOrEmpty($architecture)) { throw "Architecture $env:PROCESSOR_ARCHITECTURE is not supported yet, please create a ticket in openaev github project" }
 Write-Output "Downloading and installing OpenAEV Agent..."
 try {
+    if ("${OPENAEV_UNSECURED_CERTIFICATE}" -eq "true") {
+        # Skip TLS certificate validation: the platform explicitly runs with an
+        # unsecured (e.g. self-signed) certificate (PowerShell 5.1 compatible)
+        $previousCertificateValidationCallback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
+        [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
+    }
     Invoke-WebRequest -Uri "${OPENAEV_URL}/api/tenants/${OPENAEV_TENANT_ID}/agent/package/openaev/windows/${architecture}/service-user" -OutFile "agent-installer-service-user.exe";
     # Use the resolved full installation path
     ./agent-installer-service-user.exe /S ~OPENAEV_URL="${OPENAEV_URL}" ~ACCESS_TOKEN="${OPENAEV_TOKEN}" ~UNSECURED_CERTIFICATE=${OPENAEV_UNSECURED_CERTIFICATE} ~WITH_PROXY=${OPENAEV_WITH_PROXY} ~SERVICE_NAME="${OPENAEV_SERVICE_NAME}" ~INSTALL_DIR="$fullInstallPath" ~TENANT_ID="${OPENAEV_TENANT_ID}" ~USER="$User" ~PASSWORD="$Password" | Out-Null;
@@ -84,6 +90,9 @@ try {
     Write-Output "Note: PowerShell 7 or higher is recommended. If the issue persists, consider upgrading."
     Write-Output $_
 } finally {
+    if ("${OPENAEV_UNSECURED_CERTIFICATE}" -eq "true") {
+        [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $previousCertificateValidationCallback
+    }
     Start-Sleep -Seconds 2
     Remove-Item -Force ./agent-installer-service-user.exe;
   	if ($location -like "*C:\Windows\System32*") { Set-Location C:\Windows\System32 }

--- a/installer/windows/agent-installer-session-user.ps1
+++ b/installer/windows/agent-installer-session-user.ps1
@@ -41,6 +41,12 @@ try {
     Get-Process | Where-Object { $_.Path -eq "$AgentPath" } | Stop-Process -Force;
 
     Write-Output "Downloading and installing OpenAEV Agent...";
+    if ("${OPENAEV_UNSECURED_CERTIFICATE}" -eq "true") {
+        # Skip TLS certificate validation: the platform explicitly runs with an
+        # unsecured (e.g. self-signed) certificate (PowerShell 5.1 compatible)
+        $previousCertificateValidationCallback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
+        [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
+    }
     Invoke-WebRequest -Uri "${OPENAEV_URL}/api/tenants/${OPENAEV_TENANT_ID}/agent/package/openaev/windows/${architecture}/session-user" -OutFile "agent-installer-session-user.exe";
     ./agent-installer-session-user.exe /S ~OPENAEV_URL="${OPENAEV_URL}" ~ACCESS_TOKEN="${OPENAEV_TOKEN}" ~UNSECURED_CERTIFICATE=${OPENAEV_UNSECURED_CERTIFICATE} ~WITH_PROXY=${OPENAEV_WITH_PROXY} ~SERVICE_NAME="${OPENAEV_SERVICE_NAME}" ~INSTALL_DIR="$BasePath" ~TENANT_ID="${OPENAEV_TENANT_ID}";
 	Write-Output "OpenAEV agent has been successfully installed"
@@ -49,6 +55,9 @@ try {
     Write-Output "Note: PowerShell 7 or higher is recommended. If the issue persists, consider upgrading."
     Write-Output $_
 } finally {
+    if ("${OPENAEV_UNSECURED_CERTIFICATE}" -eq "true") {
+        [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $previousCertificateValidationCallback
+    }
     Start-Sleep -Seconds 2
     Remove-Item -Force ./agent-installer-session-user.exe;
   	if ($location -like "*C:\Windows\System32*") { Set-Location C:\Windows\System32 }

--- a/installer/windows/agent-installer.ps1
+++ b/installer/windows/agent-installer.ps1
@@ -20,6 +20,12 @@ if ([string]::IsNullOrEmpty($architecture)) { throw "Architecture $env:PROCESSOR
 
 Write-Output "Downloading and installing OpenAEV Agent..."
 try {
+    if ("${OPENAEV_UNSECURED_CERTIFICATE}" -eq "true") {
+        # Skip TLS certificate validation: the platform explicitly runs with an
+        # unsecured (e.g. self-signed) certificate (PowerShell 5.1 compatible)
+        $previousCertificateValidationCallback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
+        [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
+    }
     Invoke-WebRequest -Uri "${OPENAEV_URL}/api/tenants/${OPENAEV_TENANT_ID}/agent/package/openaev/windows/${architecture}/service" -OutFile "openaev-installer.exe";
     ./openaev-installer.exe /S ~OPENAEV_URL="${OPENAEV_URL}" ~ACCESS_TOKEN="${OPENAEV_TOKEN}" ~UNSECURED_CERTIFICATE=${OPENAEV_UNSECURED_CERTIFICATE} ~WITH_PROXY=${OPENAEV_WITH_PROXY} ~SERVICE_NAME="${OPENAEV_SERVICE_NAME}" ~INSTALL_DIR="${OPENAEV_INSTALL_DIR}" ~TENANT_ID="${OPENAEV_TENANT_ID}"  | Out-Null;
 	Write-Output "OpenAEV agent has been successfully installed"
@@ -28,6 +34,9 @@ try {
     Write-Output "Note: PowerShell 7 or higher is recommended. If the issue persists, consider upgrading."
     Write-Output $_
 } finally {
+    if ("${OPENAEV_UNSECURED_CERTIFICATE}" -eq "true") {
+        [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $previousCertificateValidationCallback
+    }
     Start-Sleep -Seconds 2
     Remove-Item -Force ./openaev-installer.exe;
   	if ($location -like "*C:\Windows\System32*") { Set-Location C:\Windows\System32 }

--- a/installer/windows/agent-upgrade-service-user.ps1
+++ b/installer/windows/agent-upgrade-service-user.ps1
@@ -1,4 +1,10 @@
 [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12;
+if ("${OPENAEV_UNSECURED_CERTIFICATE}" -eq "true") {
+    # Skip TLS certificate validation: the platform explicitly runs with an
+    # unsecured (e.g. self-signed) certificate (PowerShell 5.1 compatible)
+    $previousCertificateValidationCallback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
+    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
+}
 switch ($env:PROCESSOR_ARCHITECTURE)
 {
     "AMD64" {$architecture = "x86_64"; Break}
@@ -50,3 +56,7 @@ Remove-Item -Force $AgentPath;
 Move-Item $AgentUpgradedPath $AgentPath;
 
 sc.exe start $AgentName;
+
+if ("${OPENAEV_UNSECURED_CERTIFICATE}" -eq "true") {
+    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $previousCertificateValidationCallback
+}

--- a/installer/windows/agent-upgrade-session-user.ps1
+++ b/installer/windows/agent-upgrade-session-user.ps1
@@ -1,4 +1,10 @@
 [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12;
+if ("${OPENAEV_UNSECURED_CERTIFICATE}" -eq "true") {
+    # Skip TLS certificate validation: the platform explicitly runs with an
+    # unsecured (e.g. self-signed) certificate (PowerShell 5.1 compatible)
+    $previousCertificateValidationCallback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
+    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
+}
 switch ($env:PROCESSOR_ARCHITECTURE)
 {
     "AMD64" {$architecture = "x86_64"; Break}
@@ -82,3 +88,6 @@ if ($isElevated) {
 Remove-Item -Force ./openaev-installer.ps1
 }
 Remove-Item -Force ./openaev-installer-session-user.exe;
+if ("${OPENAEV_UNSECURED_CERTIFICATE}" -eq "true") {
+    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $previousCertificateValidationCallback
+}

--- a/installer/windows/agent-upgrade.ps1
+++ b/installer/windows/agent-upgrade.ps1
@@ -1,4 +1,10 @@
 [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12;
+if ("${OPENAEV_UNSECURED_CERTIFICATE}" -eq "true") {
+    # Skip TLS certificate validation: the platform explicitly runs with an
+    # unsecured (e.g. self-signed) certificate (PowerShell 5.1 compatible)
+    $previousCertificateValidationCallback = [System.Net.ServicePointManager]::ServerCertificateValidationCallback
+    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
+}
 switch ($env:PROCESSOR_ARCHITECTURE)
 {
 	"AMD64" {$architecture = "x86_64"; Break}
@@ -42,3 +48,6 @@ sc.exe delete "${OPENAEV_SERVICE_NAME}"
 Remove-Item -Force ./openaev-installer.ps1
 }
 Remove-Item -Force ./openaev-installer.exe;
+if ("${OPENAEV_UNSECURED_CERTIFICATE}" -eq "true") {
+    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = $previousCertificateValidationCallback
+}


### PR DESCRIPTION
## Summary

When the OpenAEV platform runs with a self-signed certificate, agent installation fails before the agent is even installed: the installer download step always enforces TLS certificate validation, even though the administrator explicitly enabled the platform's unsecured certificate flag. The platform already substitutes `${OPENAEV_UNSECURED_CERTIFICATE}` (literal `true`/`false`) into these script templates for the agent's own config - this PR makes the download commands honor it too.

- Linux/macOS (12 scripts: installer + upgrade, service / service-user / session-user): a `curl_insecure` variable is set to `-k` only when the substituted flag is `true`, and passed to every platform download `curl` (including the OpenBAS -> OpenAEV migration paths in the upgrade scripts).
- Windows (6 scripts: installer + upgrade, service / service-user / session-user): when the flag is `true`, `[System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }` is set around the download and the previous callback is restored afterwards (in `finally` for the installers). This is PowerShell 5.1 compatible - `Invoke-WebRequest -SkipCertificateCheck` only exists on PowerShell 6+.

Security posture: TLS validation is bypassed ONLY when the admin explicitly set the unsecured certificate flag on the platform. With the flag `false`, the scripts behave exactly as before.

Note: the Caldera executor install snippet (which uses `System.Net.WebClient`) lives in the platform repository frontend (`InstructionSelector.tsx`), not in this repository, and is not covered by this PR.

## Test plan

- `bash -n` passes on all 12 modified `.sh` scripts (POSIX syntax check).
- `[System.Management.Automation.Language.Parser]::ParseFile` reports zero errors on all 6 modified `.ps1` scripts.
- Repo lint `installer/windows/Run-Lint.ps1` (PSScriptAnalyzer): no issues found.
- Simulated the substituted gating logic: flag `true` yields `curl -sSfL -k <url>`, flag `false` yields the exact previous command with no extra argument.
- Manual test suggestion: deploy a platform with a self-signed certificate and `openaev.unsecured-certificate=true`, then run the generated install command on each OS; the download step should succeed. With the flag `false`, behavior must be unchanged (download fails against an untrusted certificate, as designed).

Fixes OpenAEV-Platform/openaev#3924
