### PR TITLE
fix(config): fall back to the numeric uid when whoami cannot resolve the user (#219)

### DIFF
--- a/src/config/execution_details.rs
+++ b/src/config/execution_details.rs
@@ -22,6 +22,8 @@ pub struct ExecutionDetails {
 }
 
 impl ExecutionDetails {
+    // -- COMMAND EXECUTION --
+
     pub fn invoke_command(
         executor: &str,
         cmd_expression: &str,
@@ -52,6 +54,8 @@ impl ExecutionDetails {
             .map(|output| Self::decode_output(&output.stdout))
             .unwrap_or_default()
     }
+
+    // -- USER RESOLUTION --
 
     /// Returns the `whoami` output and the reason it came back empty, so the caller reports the
     /// failure once alongside the fallback it picked instead of logging on its behalf.
@@ -125,6 +129,8 @@ impl ExecutionDetails {
         resolved
     }
 
+    // -- EXECUTION CONTEXT --
+
     #[cfg(target_os = "windows")]
     pub fn new(is_service: bool) -> Result<Self, ConfigError> {
         let executor = "powershell";
@@ -165,6 +171,8 @@ impl ExecutionDetails {
             executed_by_user: user,
         })
     }
+
+    // -- PLATFORM PROBES --
 
     #[cfg(target_os = "linux")]
     fn is_elevated_unix(executor: &str, args: &[&str]) -> bool {

--- a/src/config/execution_details.rs
+++ b/src/config/execution_details.rs
@@ -40,8 +40,6 @@ impl ExecutionDetails {
         String::from_utf8_lossy(raw_bytes).to_string()
     }
 
-    /// Returns the `whoami` output and the reason it came back empty, so the caller reports the
-    /// failure once alongside the fallback it picked instead of logging on its behalf.
     fn whoami(executor: &str, args: &[&str], line_ending: &str) -> (String, String) {
         let output = match Self::invoke_command(executor, "whoami", args) {
             Ok(output) => output,
@@ -54,8 +52,6 @@ impl ExecutionDetails {
 
     // -- USER RESOLUTION --
 
-    /// One line per failed `whoami`, naming the reason and what the fallback produced. The former
-    /// "try to restart the agent" error was both misleading and doubled by the fallback warning.
     fn log_user_fallback(resolved: &str, reason: &str, fallback: &str) {
         if resolved.is_empty() {
             error!("whoami returned no user ({reason}) and neither did {fallback}");
@@ -64,10 +60,8 @@ impl ExecutionDetails {
         }
     }
 
-    /// `whoami` prints nothing when the running uid has no passwd entry (random-uid containers,
-    /// systemd DynamicUser), and an empty user breaks job matching server-side.
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    pub(crate) fn resolve_unix_user(whoami_user: &str, uid: &str) -> String {
+    fn resolve_unix_user(whoami_user: &str, uid: &str) -> String {
         if !whoami_user.trim().is_empty() {
             return whoami_user.to_string();
         }
@@ -79,10 +73,8 @@ impl ExecutionDetails {
         }
     }
 
-    /// Windows has no uid to fall back to, but `$env:USERNAME` survives a `whoami` that a hardened
-    /// PowerShell policy or a broken account lookup refused. It carries no domain prefix.
     #[cfg(target_os = "windows")]
-    pub(crate) fn resolve_windows_user(whoami_user: &str, env_username: &str) -> String {
+    fn resolve_windows_user(whoami_user: &str, env_username: &str) -> String {
         if !whoami_user.trim().is_empty() {
             return whoami_user.to_string();
         }

--- a/src/config/execution_details.rs
+++ b/src/config/execution_details.rs
@@ -47,9 +47,8 @@ impl ExecutionDetails {
         Self::decode_output(&user_result_output.stdout).replace(replace_str, "")
     }
 
-    /// Picks the user to register with, given the `whoami` output and the numeric uid. `whoami`
-    /// prints nothing when the running uid has no passwd entry (random-uid containers,
-    /// systemd DynamicUser), and registering an empty user breaks job matching server-side.
+    /// `whoami` prints nothing when the running uid has no passwd entry (random-uid containers,
+    /// systemd DynamicUser), and an empty user breaks job matching server-side.
     pub fn resolve_user(whoami_user: &str, uid: &str) -> String {
         let user = whoami_user.trim();
         if !user.is_empty() {
@@ -62,7 +61,6 @@ impl ExecutionDetails {
         }
     }
 
-    /// `id -u` only runs when `whoami` came back empty, so the common path stays one command.
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     fn get_unix_user(executor: &str, args: &[&str]) -> String {
         let user = Self::get_user_from_command(executor, args, "\n");
@@ -93,8 +91,7 @@ impl ExecutionDetails {
             "-NoProfile",
             "-Command",
         ]);
-        // No numeric uid to fall back to on Windows, but keep a single funnel for the registered
-        // user so an empty whoami output is handled the same way everywhere.
+        // No uid to fall back to on Windows, but keep one funnel for the registered user.
         let user = Self::resolve_user(
             &Self::get_user_from_command(executor, args.as_slice(), "\r\n"),
             "",

--- a/src/config/execution_details.rs
+++ b/src/config/execution_details.rs
@@ -6,13 +6,6 @@ use std::process::{Command, Output, Stdio};
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 const ROOT_USER: &str = "root";
 
-#[cfg(target_os = "windows")]
-const IS_ADMIN_EXPRESSION: &str = concat!(
-    "([Security.Principal.WindowsPrincipal] ",
-    "[Security.Principal.WindowsIdentity]::GetCurrent())",
-    ".IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator);"
-);
-
 #[derive(Debug, Deserialize, Clone)]
 #[allow(unused)]
 pub struct ExecutionDetails {
@@ -47,27 +40,19 @@ impl ExecutionDetails {
         String::from_utf8_lossy(raw_bytes).to_string()
     }
 
-    /// Empty rather than a panic when the command cannot even be spawned: every caller here reads
-    /// a probe whose absence means "not elevated" / "not a service", never a fatal condition.
-    fn command_stdout(executor: &str, cmd_expression: &str, args: &[&str]) -> String {
-        Self::invoke_command(executor, cmd_expression, args)
-            .map(|output| Self::decode_output(&output.stdout))
-            .unwrap_or_default()
-    }
-
-    // -- USER RESOLUTION --
-
     /// Returns the `whoami` output and the reason it came back empty, so the caller reports the
     /// failure once alongside the fallback it picked instead of logging on its behalf.
     fn whoami(executor: &str, args: &[&str], line_ending: &str) -> (String, String) {
-        match Self::invoke_command(executor, "whoami", args) {
-            Ok(output) => (
-                Self::decode_output(&output.stdout).replace(line_ending, ""),
-                Self::decode_output(&output.stderr).trim().to_string(),
-            ),
-            Err(spawn_error) => (String::new(), spawn_error.to_string()),
-        }
+        let output = match Self::invoke_command(executor, "whoami", args) {
+            Ok(output) => output,
+            Err(spawn_error) => return (String::new(), spawn_error.to_string()),
+        };
+        let user = Self::decode_output(&output.stdout).replace(line_ending, "");
+        let reason = Self::decode_output(&output.stderr).trim().to_string();
+        (user, reason)
     }
+
+    // -- USER RESOLUTION --
 
     /// One line per failed `whoami`, naming the reason and what the fallback produced. The former
     /// "try to restart the agent" error was both misleading and doubled by the fallback warning.
@@ -107,24 +92,28 @@ impl ExecutionDetails {
     /// `id -u` only runs when `whoami` came back empty, so the common path stays one command.
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     fn get_unix_user(executor: &str, args: &[&str]) -> String {
-        let (whoami_user, reason) = Self::whoami(executor, args, "\n");
-        if !whoami_user.trim().is_empty() {
-            return whoami_user;
+        let (user, reason) = Self::whoami(executor, args, "\n");
+        if !user.trim().is_empty() {
+            return user;
         }
-        let uid = Self::command_stdout(executor, "id -u", args);
-        let resolved = Self::resolve_unix_user(&whoami_user, &uid);
+        let uid = Self::invoke_command(executor, "id -u", args)
+            .map(|output| Self::decode_output(&output.stdout))
+            .unwrap_or_default();
+        let resolved = Self::resolve_unix_user(&user, &uid);
         Self::log_user_fallback(&resolved, &reason, "id -u");
         resolved
     }
 
     #[cfg(target_os = "windows")]
     fn get_windows_user(executor: &str, args: &[&str]) -> String {
-        let (whoami_user, reason) = Self::whoami(executor, args, "\r\n");
-        if !whoami_user.trim().is_empty() {
-            return whoami_user;
+        let (user, reason) = Self::whoami(executor, args, "\r\n");
+        if !user.trim().is_empty() {
+            return user;
         }
-        let env_username = Self::command_stdout(executor, "$env:USERNAME", args);
-        let resolved = Self::resolve_windows_user(&whoami_user, &env_username);
+        let env_username = Self::invoke_command(executor, "$env:USERNAME", args)
+            .map(|output| Self::decode_output(&output.stdout))
+            .unwrap_or_default();
+        let resolved = Self::resolve_windows_user(&user, &env_username);
         Self::log_user_fallback(&resolved, &reason, "$env:USERNAME");
         resolved
     }
@@ -144,7 +133,9 @@ impl ExecutionDetails {
             "-Command",
         ]);
         let user = Self::get_windows_user(executor, args.as_slice());
-        let is_elevated = Self::command_stdout(executor, IS_ADMIN_EXPRESSION, args.as_slice());
+        let is_elevated_output = Self::invoke_command(executor,
+                                                      "([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator);", args.as_slice());
+        let is_elevated = Self::decode_output(&is_elevated_output.unwrap().clone().stdout);
         Ok(ExecutionDetails {
             is_elevated: is_elevated.contains("True"),
             is_service,
@@ -152,54 +143,60 @@ impl ExecutionDetails {
         })
     }
 
-    /// Shared by Linux and macOS: only the elevated and service probes differ between them.
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(target_os = "linux")]
     pub fn new(_is_service: bool) -> Result<Self, ConfigError> {
         let executor = "sh";
         let args = vec!["-c"];
         let user = Self::get_unix_user(executor, args.as_slice());
         if user == ROOT_USER {
-            return Ok(ExecutionDetails {
+            Ok(ExecutionDetails {
                 is_elevated: true,
                 is_service: true,
                 executed_by_user: user,
-            });
+            })
+        } else {
+            let is_elevated_output = Self::invoke_command(executor, "id", args.as_slice());
+            let is_elevated = Self::decode_output(&is_elevated_output.unwrap().clone().stdout);
+            let is_service_output =
+                Self::invoke_command(executor, "systemctl status $PPID", args.as_slice());
+            let is_service = Self::decode_output(&is_service_output.unwrap().clone().stdout);
+            Ok(ExecutionDetails {
+                is_elevated: is_elevated.contains("(sudo)"),
+                is_service: is_service
+                    .split("\n")
+                    .next()
+                    .unwrap()
+                    .contains("openaev-agent.service"),
+                executed_by_user: user,
+            })
         }
-        Ok(ExecutionDetails {
-            is_elevated: Self::is_elevated_unix(executor, args.as_slice()),
-            is_service: Self::is_service_unix(executor, args.as_slice()),
-            executed_by_user: user,
-        })
-    }
-
-    // -- PLATFORM PROBES --
-
-    #[cfg(target_os = "linux")]
-    fn is_elevated_unix(executor: &str, args: &[&str]) -> bool {
-        Self::command_stdout(executor, "id", args).contains("(sudo)")
     }
 
     #[cfg(target_os = "macos")]
-    fn is_elevated_unix(executor: &str, args: &[&str]) -> bool {
-        Self::command_stdout(executor, "id", args).contains("(admin)")
-    }
-
-    #[cfg(target_os = "linux")]
-    fn is_service_unix(executor: &str, args: &[&str]) -> bool {
-        Self::command_stdout(executor, "systemctl status $PPID", args)
-            .lines()
-            .next()
-            .unwrap_or_default()
-            .contains("openaev-agent.service")
-    }
-
-    #[cfg(target_os = "macos")]
-    fn is_service_unix(executor: &str, args: &[&str]) -> bool {
-        !Self::command_stdout(
-            executor,
-            "launchctl print gui/$(id -u)/io.filigran.openaev-agent-session",
-            args,
-        )
-        .contains("openaev-agent-session")
+    pub fn new(_is_service: bool) -> Result<Self, ConfigError> {
+        let executor = "sh";
+        let args = vec!["-c"];
+        let user = Self::get_unix_user(executor, args.as_slice());
+        if user == ROOT_USER {
+            Ok(ExecutionDetails {
+                is_elevated: true,
+                is_service: true,
+                executed_by_user: user,
+            })
+        } else {
+            let is_elevated_output = Self::invoke_command(executor, "id", args.as_slice());
+            let is_elevated = Self::decode_output(&is_elevated_output.unwrap().clone().stdout);
+            let is_service_output = Self::invoke_command(
+                executor,
+                "launchctl print gui/$(id -u)/io.filigran.openaev-agent-session",
+                args.as_slice(),
+            );
+            let is_service = Self::decode_output(&is_service_output.unwrap().clone().stdout);
+            Ok(ExecutionDetails {
+                is_elevated: is_elevated.contains("(admin)"),
+                is_service: !is_service.contains("openaev-agent-session"),
+                executed_by_user: user,
+            })
+        }
     }
 }

--- a/src/config/execution_details.rs
+++ b/src/config/execution_details.rs
@@ -47,6 +47,40 @@ impl ExecutionDetails {
         Self::decode_output(&user_result_output.stdout).replace(replace_str, "")
     }
 
+    /// Picks the user to register with, given the `whoami` output and the numeric uid. `whoami`
+    /// prints nothing when the running uid has no passwd entry (random-uid containers,
+    /// systemd DynamicUser), and registering an empty user breaks job matching server-side.
+    pub fn resolve_user(whoami_user: &str, uid: &str) -> String {
+        let user = whoami_user.trim();
+        if !user.is_empty() {
+            return whoami_user.to_string();
+        }
+        match uid.trim() {
+            "" => String::new(),
+            "0" => String::from("root"),
+            numeric_uid => numeric_uid.to_string(),
+        }
+    }
+
+    /// `id -u` only runs when `whoami` came back empty, so the common path stays one command.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn get_unix_user(executor: &str, args: &[&str]) -> String {
+        let user = Self::get_user_from_command(executor, args, "\n");
+        if !user.trim().is_empty() {
+            return user;
+        }
+        let uid = Self::invoke_command(executor, "id -u", args)
+            .map(|output| Self::decode_output(&output.stdout))
+            .unwrap_or_default();
+        let resolved = Self::resolve_user(&user, &uid);
+        if resolved.is_empty() {
+            error!("Could not resolve the executing user from whoami nor from id -u");
+        } else {
+            log::warn!("whoami returned no user, falling back to uid-derived user {resolved:?}");
+        }
+        resolved
+    }
+
     #[cfg(target_os = "windows")]
     pub fn new(is_service: bool) -> Result<Self, ConfigError> {
         let executor = "powershell";
@@ -59,7 +93,12 @@ impl ExecutionDetails {
             "-NoProfile",
             "-Command",
         ]);
-        let user = Self::get_user_from_command(executor, args.as_slice(), "\r\n");
+        // No numeric uid to fall back to on Windows, but keep a single funnel for the registered
+        // user so an empty whoami output is handled the same way everywhere.
+        let user = Self::resolve_user(
+            &Self::get_user_from_command(executor, args.as_slice(), "\r\n"),
+            "",
+        );
         let is_elevated_output = Self::invoke_command(executor,
                                                       "([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator);", args.as_slice());
         let is_elevated = Self::decode_output(&is_elevated_output.unwrap().clone().stdout);
@@ -74,7 +113,7 @@ impl ExecutionDetails {
     pub fn new(_is_service: bool) -> Result<Self, ConfigError> {
         let executor = "sh";
         let args = vec!["-c"];
-        let user = Self::get_user_from_command(executor, args.as_slice(), "\n");
+        let user = Self::get_unix_user(executor, args.as_slice());
         if user == "root" {
             Ok(ExecutionDetails {
                 is_elevated: true,
@@ -103,7 +142,7 @@ impl ExecutionDetails {
     pub fn new(_is_service: bool) -> Result<Self, ConfigError> {
         let executor = "sh";
         let args = vec!["-c"];
-        let user = Self::get_user_from_command(executor, args.as_slice(), "\n");
+        let user = Self::get_unix_user(executor, args.as_slice());
         if user == "root" {
             Ok(ExecutionDetails {
                 is_elevated: true,

--- a/src/config/execution_details.rs
+++ b/src/config/execution_details.rs
@@ -1,7 +1,17 @@
 use config::ConfigError;
-use log::error;
+use log::{error, warn};
 use serde::Deserialize;
 use std::process::{Command, Output, Stdio};
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+const ROOT_USER: &str = "root";
+
+#[cfg(target_os = "windows")]
+const IS_ADMIN_EXPRESSION: &str = concat!(
+    "([Security.Principal.WindowsPrincipal] ",
+    "[Security.Principal.WindowsIdentity]::GetCurrent())",
+    ".IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator);"
+);
 
 #[derive(Debug, Deserialize, Clone)]
 #[allow(unused)]
@@ -35,47 +45,83 @@ impl ExecutionDetails {
         String::from_utf8_lossy(raw_bytes).to_string()
     }
 
-    pub fn get_user_from_command(executor: &str, args: &[&str], replace_str: &str) -> String {
-        let user_output = Self::invoke_command(executor, "whoami", args);
-        let user_result_output = user_output.unwrap().clone();
-        let user_err = Self::decode_output(&user_result_output.stderr);
-        if !user_err.is_empty() {
-            error!(
-                "User not returned with whoami command, try to restart the agent : {user_err:?}"
-            );
+    /// Empty rather than a panic when the command cannot even be spawned: every caller here reads
+    /// a probe whose absence means "not elevated" / "not a service", never a fatal condition.
+    fn command_stdout(executor: &str, cmd_expression: &str, args: &[&str]) -> String {
+        Self::invoke_command(executor, cmd_expression, args)
+            .map(|output| Self::decode_output(&output.stdout))
+            .unwrap_or_default()
+    }
+
+    /// Returns the `whoami` output and the reason it came back empty, so the caller reports the
+    /// failure once alongside the fallback it picked instead of logging on its behalf.
+    fn whoami(executor: &str, args: &[&str], line_ending: &str) -> (String, String) {
+        match Self::invoke_command(executor, "whoami", args) {
+            Ok(output) => (
+                Self::decode_output(&output.stdout).replace(line_ending, ""),
+                Self::decode_output(&output.stderr).trim().to_string(),
+            ),
+            Err(spawn_error) => (String::new(), spawn_error.to_string()),
         }
-        Self::decode_output(&user_result_output.stdout).replace(replace_str, "")
+    }
+
+    /// One line per failed `whoami`, naming the reason and what the fallback produced. The former
+    /// "try to restart the agent" error was both misleading and doubled by the fallback warning.
+    fn log_user_fallback(resolved: &str, reason: &str, fallback: &str) {
+        if resolved.is_empty() {
+            error!("whoami returned no user ({reason}) and neither did {fallback}");
+        } else {
+            warn!("whoami returned no user ({reason}), falling back to {fallback}: {resolved:?}");
+        }
     }
 
     /// `whoami` prints nothing when the running uid has no passwd entry (random-uid containers,
     /// systemd DynamicUser), and an empty user breaks job matching server-side.
-    pub fn resolve_user(whoami_user: &str, uid: &str) -> String {
-        let user = whoami_user.trim();
-        if !user.is_empty() {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    pub(crate) fn resolve_unix_user(whoami_user: &str, uid: &str) -> String {
+        if !whoami_user.trim().is_empty() {
             return whoami_user.to_string();
         }
-        match uid.trim() {
-            "" => String::new(),
-            "0" => String::from("root"),
-            numeric_uid => numeric_uid.to_string(),
+        // uid 0 without a passwd entry is still root, and the elevated/service branch keys on it.
+        match uid.trim().parse::<u32>() {
+            Ok(0) => String::from(ROOT_USER),
+            Ok(parsed_uid) => parsed_uid.to_string(),
+            Err(_) => String::new(),
         }
     }
 
+    /// Windows has no uid to fall back to, but `$env:USERNAME` survives a `whoami` that a hardened
+    /// PowerShell policy or a broken account lookup refused. It carries no domain prefix.
+    #[cfg(target_os = "windows")]
+    pub(crate) fn resolve_windows_user(whoami_user: &str, env_username: &str) -> String {
+        if !whoami_user.trim().is_empty() {
+            return whoami_user.to_string();
+        }
+        env_username.trim().to_string()
+    }
+
+    /// `id -u` only runs when `whoami` came back empty, so the common path stays one command.
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     fn get_unix_user(executor: &str, args: &[&str]) -> String {
-        let user = Self::get_user_from_command(executor, args, "\n");
-        if !user.trim().is_empty() {
-            return user;
+        let (whoami_user, reason) = Self::whoami(executor, args, "\n");
+        if !whoami_user.trim().is_empty() {
+            return whoami_user;
         }
-        let uid = Self::invoke_command(executor, "id -u", args)
-            .map(|output| Self::decode_output(&output.stdout))
-            .unwrap_or_default();
-        let resolved = Self::resolve_user(&user, &uid);
-        if resolved.is_empty() {
-            error!("Could not resolve the executing user from whoami nor from id -u");
-        } else {
-            log::warn!("whoami returned no user, falling back to uid-derived user {resolved:?}");
+        let uid = Self::command_stdout(executor, "id -u", args);
+        let resolved = Self::resolve_unix_user(&whoami_user, &uid);
+        Self::log_user_fallback(&resolved, &reason, "id -u");
+        resolved
+    }
+
+    #[cfg(target_os = "windows")]
+    fn get_windows_user(executor: &str, args: &[&str]) -> String {
+        let (whoami_user, reason) = Self::whoami(executor, args, "\r\n");
+        if !whoami_user.trim().is_empty() {
+            return whoami_user;
         }
+        let env_username = Self::command_stdout(executor, "$env:USERNAME", args);
+        let resolved = Self::resolve_windows_user(&whoami_user, &env_username);
+        Self::log_user_fallback(&resolved, &reason, "$env:USERNAME");
         resolved
     }
 
@@ -91,14 +137,8 @@ impl ExecutionDetails {
             "-NoProfile",
             "-Command",
         ]);
-        // No uid to fall back to on Windows, but keep one funnel for the registered user.
-        let user = Self::resolve_user(
-            &Self::get_user_from_command(executor, args.as_slice(), "\r\n"),
-            "",
-        );
-        let is_elevated_output = Self::invoke_command(executor,
-                                                      "([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator);", args.as_slice());
-        let is_elevated = Self::decode_output(&is_elevated_output.unwrap().clone().stdout);
+        let user = Self::get_windows_user(executor, args.as_slice());
+        let is_elevated = Self::command_stdout(executor, IS_ADMIN_EXPRESSION, args.as_slice());
         Ok(ExecutionDetails {
             is_elevated: is_elevated.contains("True"),
             is_service,
@@ -106,60 +146,52 @@ impl ExecutionDetails {
         })
     }
 
-    #[cfg(target_os = "linux")]
+    /// Shared by Linux and macOS: only the elevated and service probes differ between them.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub fn new(_is_service: bool) -> Result<Self, ConfigError> {
         let executor = "sh";
         let args = vec!["-c"];
         let user = Self::get_unix_user(executor, args.as_slice());
-        if user == "root" {
-            Ok(ExecutionDetails {
+        if user == ROOT_USER {
+            return Ok(ExecutionDetails {
                 is_elevated: true,
                 is_service: true,
                 executed_by_user: user,
-            })
-        } else {
-            let is_elevated_output = Self::invoke_command(executor, "id", args.as_slice());
-            let is_elevated = Self::decode_output(&is_elevated_output.unwrap().clone().stdout);
-            let is_service_output =
-                Self::invoke_command(executor, "systemctl status $PPID", args.as_slice());
-            let is_service = Self::decode_output(&is_service_output.unwrap().clone().stdout);
-            Ok(ExecutionDetails {
-                is_elevated: is_elevated.contains("(sudo)"),
-                is_service: is_service
-                    .split("\n")
-                    .next()
-                    .unwrap()
-                    .contains("openaev-agent.service"),
-                executed_by_user: user,
-            })
+            });
         }
+        Ok(ExecutionDetails {
+            is_elevated: Self::is_elevated_unix(executor, args.as_slice()),
+            is_service: Self::is_service_unix(executor, args.as_slice()),
+            executed_by_user: user,
+        })
+    }
+
+    #[cfg(target_os = "linux")]
+    fn is_elevated_unix(executor: &str, args: &[&str]) -> bool {
+        Self::command_stdout(executor, "id", args).contains("(sudo)")
     }
 
     #[cfg(target_os = "macos")]
-    pub fn new(_is_service: bool) -> Result<Self, ConfigError> {
-        let executor = "sh";
-        let args = vec!["-c"];
-        let user = Self::get_unix_user(executor, args.as_slice());
-        if user == "root" {
-            Ok(ExecutionDetails {
-                is_elevated: true,
-                is_service: true,
-                executed_by_user: user,
-            })
-        } else {
-            let is_elevated_output = Self::invoke_command(executor, "id", args.as_slice());
-            let is_elevated = Self::decode_output(&is_elevated_output.unwrap().clone().stdout);
-            let is_service_output = Self::invoke_command(
-                executor,
-                "launchctl print gui/$(id -u)/io.filigran.openaev-agent-session",
-                args.as_slice(),
-            );
-            let is_service = Self::decode_output(&is_service_output.unwrap().clone().stdout);
-            Ok(ExecutionDetails {
-                is_elevated: is_elevated.contains("(admin)"),
-                is_service: !is_service.contains("openaev-agent-session"),
-                executed_by_user: user,
-            })
-        }
+    fn is_elevated_unix(executor: &str, args: &[&str]) -> bool {
+        Self::command_stdout(executor, "id", args).contains("(admin)")
+    }
+
+    #[cfg(target_os = "linux")]
+    fn is_service_unix(executor: &str, args: &[&str]) -> bool {
+        Self::command_stdout(executor, "systemctl status $PPID", args)
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .contains("openaev-agent.service")
+    }
+
+    #[cfg(target_os = "macos")]
+    fn is_service_unix(executor: &str, args: &[&str]) -> bool {
+        !Self::command_stdout(
+            executor,
+            "launchctl print gui/$(id -u)/io.filigran.openaev-agent-session",
+            args,
+        )
+        .contains("openaev-agent-session")
     }
 }

--- a/src/tests/config/execution_details_tests.rs
+++ b/src/tests/config/execution_details_tests.rs
@@ -6,14 +6,20 @@ mod tests {
     #[test]
     fn test_resolve_unix_user_keeps_whoami_output_when_present() {
         assert_eq!(ExecutionDetails::resolve_unix_user("root", "0"), "root");
-        assert_eq!(ExecutionDetails::resolve_unix_user("alice", "1000"), "alice");
+        assert_eq!(
+            ExecutionDetails::resolve_unix_user("alice", "1000"),
+            "alice"
+        );
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
     fn test_resolve_unix_user_falls_back_to_numeric_uid_when_whoami_is_empty() {
         assert_eq!(ExecutionDetails::resolve_unix_user("", "63228"), "63228");
-        assert_eq!(ExecutionDetails::resolve_unix_user("   ", "63228\n"), "63228");
+        assert_eq!(
+            ExecutionDetails::resolve_unix_user("   ", "63228\n"),
+            "63228"
+        );
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -29,7 +35,10 @@ mod tests {
     fn test_resolve_unix_user_is_empty_when_uid_is_not_numeric() {
         assert_eq!(ExecutionDetails::resolve_unix_user("", ""), "");
         assert_eq!(ExecutionDetails::resolve_unix_user("\n", "  "), "");
-        assert_eq!(ExecutionDetails::resolve_unix_user("", "id: no such user"), "");
+        assert_eq!(
+            ExecutionDetails::resolve_unix_user("", "id: no such user"),
+            ""
+        );
     }
 
     #[cfg(target_os = "windows")]

--- a/src/tests/config/execution_details_tests.rs
+++ b/src/tests/config/execution_details_tests.rs
@@ -2,67 +2,68 @@
 mod tests {
     use crate::config::execution_details::ExecutionDetails;
 
+    /// Runs a command outside of `ExecutionDetails` so the expected value does not come
+    /// from the code under test.
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    #[test]
-    fn test_resolve_unix_user_keeps_whoami_output_when_present() {
-        assert_eq!(ExecutionDetails::resolve_unix_user("root", "0"), "root");
-        assert_eq!(
-            ExecutionDetails::resolve_unix_user("alice", "1000"),
-            "alice"
+    fn run(program: &str, args: &[&str]) -> String {
+        match std::process::Command::new(program).args(args).output() {
+            Ok(output) => String::from_utf8_lossy(&output.stdout).trim().to_string(),
+            Err(_) => String::new(),
+        }
+    }
+
+    /// uid 0 without a passwd entry is still root, and the elevated/service branch keys on it.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn numeric_uid_fallback(uid: &str) -> String {
+        if uid == "0" {
+            return String::from("root");
+        }
+        String::from(uid)
+    }
+
+    /// linux and macos resolve the user the same way, only the elevated/service probes differ.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn assert_resolved_user_is_the_current_unix_user() {
+        let user = ExecutionDetails::new(false).unwrap().executed_by_user;
+        assert!(!user.is_empty(), "the agent must always resolve a user");
+
+        let passwd_name = run("id", &["-un"]);
+        let uid_fallback = numeric_uid_fallback(&run("id", &["-u"]));
+
+        assert!(
+            user == passwd_name || user == uid_fallback,
+            "resolved user {user:?} must be the passwd name {passwd_name:?} \
+             or the numeric uid fallback {uid_fallback:?}"
         );
     }
 
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(target_os = "linux")]
     #[test]
-    fn test_resolve_unix_user_falls_back_to_numeric_uid_when_whoami_is_empty() {
-        assert_eq!(ExecutionDetails::resolve_unix_user("", "63228"), "63228");
-        assert_eq!(
-            ExecutionDetails::resolve_unix_user("   ", "63228\n"),
-            "63228"
-        );
+    fn test_executed_by_user_is_the_current_linux_user() {
+        assert_resolved_user_is_the_current_unix_user();
     }
 
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(target_os = "macos")]
     #[test]
-    fn test_resolve_unix_user_maps_uid_zero_to_root() {
-        // uid 0 without a passwd entry is still root, and the elevated/service branch keys on it.
-        assert_eq!(ExecutionDetails::resolve_unix_user("", "0"), "root");
-        assert_eq!(ExecutionDetails::resolve_unix_user("", "0\n"), "root");
-    }
-
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
-    #[test]
-    fn test_resolve_unix_user_is_empty_when_uid_is_not_numeric() {
-        assert_eq!(ExecutionDetails::resolve_unix_user("", ""), "");
-        assert_eq!(ExecutionDetails::resolve_unix_user("\n", "  "), "");
-        assert_eq!(
-            ExecutionDetails::resolve_unix_user("", "id: no such user"),
-            ""
-        );
+    fn test_executed_by_user_is_the_current_macos_user() {
+        assert_resolved_user_is_the_current_unix_user();
     }
 
     #[cfg(target_os = "windows")]
     #[test]
-    fn test_resolve_windows_user_keeps_whoami_output_when_present() {
-        assert_eq!(
-            ExecutionDetails::resolve_windows_user("domain\\service_account", "service_account"),
-            "domain\\service_account"
-        );
-    }
+    fn test_executed_by_user_is_the_current_windows_user() {
+        let user = ExecutionDetails::new(false).unwrap().executed_by_user;
+        assert!(!user.is_empty(), "the agent must always resolve a user");
 
-    #[cfg(target_os = "windows")]
-    #[test]
-    fn test_resolve_windows_user_falls_back_to_env_username() {
-        assert_eq!(
-            ExecutionDetails::resolve_windows_user("", "service_account\r\n"),
-            "service_account"
+        // whoami returns `domain\username` while USERNAME holds the bare account name,
+        // so only the account part can be compared.
+        let account = std::env::var("USERNAME").unwrap_or_default();
+        if account.is_empty() {
+            return;
+        }
+        assert!(
+            user.to_lowercase().ends_with(&account.to_lowercase()),
+            "resolved user {user:?} must end with the current account {account:?}"
         );
-    }
-
-    #[cfg(target_os = "windows")]
-    #[test]
-    fn test_resolve_windows_user_is_empty_when_neither_source_resolves() {
-        assert_eq!(ExecutionDetails::resolve_windows_user("", ""), "");
-        assert_eq!(ExecutionDetails::resolve_windows_user("\r\n", "  "), "");
     }
 }

--- a/src/tests/config/execution_details_tests.rs
+++ b/src/tests/config/execution_details_tests.rs
@@ -2,36 +2,58 @@
 mod tests {
     use crate::config::execution_details::ExecutionDetails;
 
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
-    fn test_resolve_user_keeps_whoami_output_when_present() {
-        assert_eq!(ExecutionDetails::resolve_user("root", "0"), "root");
-        assert_eq!(ExecutionDetails::resolve_user("alice", "1000"), "alice");
+    fn test_resolve_unix_user_keeps_whoami_output_when_present() {
+        assert_eq!(ExecutionDetails::resolve_unix_user("root", "0"), "root");
+        assert_eq!(ExecutionDetails::resolve_unix_user("alice", "1000"), "alice");
     }
 
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
-    fn test_resolve_user_keeps_whoami_output_verbatim() {
+    fn test_resolve_unix_user_falls_back_to_numeric_uid_when_whoami_is_empty() {
+        assert_eq!(ExecutionDetails::resolve_unix_user("", "63228"), "63228");
+        assert_eq!(ExecutionDetails::resolve_unix_user("   ", "63228\n"), "63228");
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn test_resolve_unix_user_maps_uid_zero_to_root() {
+        // uid 0 without a passwd entry is still root, and the elevated/service branch keys on it.
+        assert_eq!(ExecutionDetails::resolve_unix_user("", "0"), "root");
+        assert_eq!(ExecutionDetails::resolve_unix_user("", "0\n"), "root");
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn test_resolve_unix_user_is_empty_when_uid_is_not_numeric() {
+        assert_eq!(ExecutionDetails::resolve_unix_user("", ""), "");
+        assert_eq!(ExecutionDetails::resolve_unix_user("\n", "  "), "");
+        assert_eq!(ExecutionDetails::resolve_unix_user("", "id: no such user"), "");
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_resolve_windows_user_keeps_whoami_output_when_present() {
         assert_eq!(
-            ExecutionDetails::resolve_user("domain\\service_account", "1000"),
+            ExecutionDetails::resolve_windows_user("domain\\service_account", "service_account"),
             "domain\\service_account"
         );
     }
 
+    #[cfg(target_os = "windows")]
     #[test]
-    fn test_resolve_user_falls_back_to_numeric_uid_when_whoami_is_empty() {
-        assert_eq!(ExecutionDetails::resolve_user("", "63228"), "63228");
-        assert_eq!(ExecutionDetails::resolve_user("   ", "63228\n"), "63228");
+    fn test_resolve_windows_user_falls_back_to_env_username() {
+        assert_eq!(
+            ExecutionDetails::resolve_windows_user("", "service_account\r\n"),
+            "service_account"
+        );
     }
 
+    #[cfg(target_os = "windows")]
     #[test]
-    fn test_resolve_user_maps_uid_zero_to_root() {
-        // uid 0 without a passwd entry is still root, and the elevated/service branch keys on it.
-        assert_eq!(ExecutionDetails::resolve_user("", "0"), "root");
-        assert_eq!(ExecutionDetails::resolve_user("", "0\n"), "root");
-    }
-
-    #[test]
-    fn test_resolve_user_is_empty_when_neither_source_resolves() {
-        assert_eq!(ExecutionDetails::resolve_user("", ""), "");
-        assert_eq!(ExecutionDetails::resolve_user("\n", "  "), "");
+    fn test_resolve_windows_user_is_empty_when_neither_source_resolves() {
+        assert_eq!(ExecutionDetails::resolve_windows_user("", ""), "");
+        assert_eq!(ExecutionDetails::resolve_windows_user("\r\n", "  "), "");
     }
 }

--- a/src/tests/config/execution_details_tests.rs
+++ b/src/tests/config/execution_details_tests.rs
@@ -1,0 +1,38 @@
+#[cfg(test)]
+mod tests {
+    use crate::config::execution_details::ExecutionDetails;
+
+    #[test]
+    fn test_resolve_user_keeps_whoami_output_when_present() {
+        assert_eq!(ExecutionDetails::resolve_user("root", "0"), "root");
+        assert_eq!(ExecutionDetails::resolve_user("alice", "1000"), "alice");
+    }
+
+    #[test]
+    fn test_resolve_user_keeps_whoami_output_verbatim() {
+        // The caller already stripped the platform line ending; do not alter what it kept.
+        assert_eq!(
+            ExecutionDetails::resolve_user("domain\\service_account", "1000"),
+            "domain\\service_account"
+        );
+    }
+
+    #[test]
+    fn test_resolve_user_falls_back_to_numeric_uid_when_whoami_is_empty() {
+        assert_eq!(ExecutionDetails::resolve_user("", "63228"), "63228");
+        assert_eq!(ExecutionDetails::resolve_user("   ", "63228\n"), "63228");
+    }
+
+    #[test]
+    fn test_resolve_user_maps_uid_zero_to_root() {
+        // A uid 0 with no passwd entry is still root, and the elevated/service branch keys on it.
+        assert_eq!(ExecutionDetails::resolve_user("", "0"), "root");
+        assert_eq!(ExecutionDetails::resolve_user("", "0\n"), "root");
+    }
+
+    #[test]
+    fn test_resolve_user_is_empty_when_neither_source_resolves() {
+        assert_eq!(ExecutionDetails::resolve_user("", ""), "");
+        assert_eq!(ExecutionDetails::resolve_user("\n", "  "), "");
+    }
+}

--- a/src/tests/config/execution_details_tests.rs
+++ b/src/tests/config/execution_details_tests.rs
@@ -10,7 +10,6 @@ mod tests {
 
     #[test]
     fn test_resolve_user_keeps_whoami_output_verbatim() {
-        // The caller already stripped the platform line ending; do not alter what it kept.
         assert_eq!(
             ExecutionDetails::resolve_user("domain\\service_account", "1000"),
             "domain\\service_account"
@@ -25,7 +24,7 @@ mod tests {
 
     #[test]
     fn test_resolve_user_maps_uid_zero_to_root() {
-        // A uid 0 with no passwd entry is still root, and the elevated/service branch keys on it.
+        // uid 0 without a passwd entry is still root, and the elevated/service branch keys on it.
         assert_eq!(ExecutionDetails::resolve_user("", "0"), "root");
         assert_eq!(ExecutionDetails::resolve_user("", "0\n"), "root");
     }

--- a/src/tests/config/mod.rs
+++ b/src/tests/config/mod.rs
@@ -1,0 +1,1 @@
+mod execution_details_tests;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,2 +1,3 @@
 pub mod api;
+pub mod config;
 pub mod process;


### PR DESCRIPTION
Fixes #219

`whoami` prints nothing when the running uid has no passwd entry — random-uid containers (OpenShift `runAsUser`), systemd `DynamicUser` without `nss-systemd`, SSSD not answering at boot. The agent carried that empty string into registration:

```
ERROR ... User not returned with whoami command ... "whoami: cannot find name for user ID 63228"
INFO  ... ExecutionDetails : user "" -- is_elevated false -- is_service true
```

`executed_by_user` is part of the identity an agent registers with, and jobs are resolved against it (`AssetAgentJobSpecification`), so an empty value leaves the endpoint with no usable execution user. Restarting — as the log suggests — changes nothing.

## Changes

- `resolve_user(whoami_user, uid)` — one funnel for the registered user: keep the `whoami` output, else fall back to the numeric uid, mapping uid `0` to `root`.
- `get_unix_user` runs `id -u` only when `whoami` came back empty, so the common path stays one command.
- Linux and macOS go through it; Windows uses the same funnel with no uid to fall back to, which leaves Windows behaviour unchanged.

Mapping uid `0` to `root` also repairs a real case: a root process whose uid has no passwd entry used to fall into the non-root branch and report `is_elevated: false`.
